### PR TITLE
Always run a first scan at app startup

### DIFF
--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/AppSecServiceInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/AppSecServiceInitListener.java
@@ -30,7 +30,8 @@ public class AppSecServiceInitListener extends AbstractInitListener {
             AppSecService appSecService = AppSecService.getInstance();
             appSecService.init();
             LOGGER.info("AppSecService initialized");
-            appSecService.scheduleAutomaticScan();
+            appSecService.scanForVulnerabilities()
+                    .thenRun(appSecService::scheduleAutomaticScan);
             LOGGER.info("AppSecService auto-scan scheduled every "
                     + appSecService.getConfiguration().getAutoScanInterval()
                             .toString());


### PR DESCRIPTION
This always runs a scan at app startup before scheduling automatic scans.

Temporarily fixes #42 (until proper vulnerability data cache)