### PR TITLE
Add method to get new vulnerabilities from scan event

### DIFF
--- a/appsec-kit-backend/pom.xml
+++ b/appsec-kit-backend/pom.xml
@@ -57,6 +57,12 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecScanEvent.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecScanEvent.java
@@ -9,6 +9,11 @@
 package com.vaadin.appsec.backend;
 
 import java.util.EventObject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.vaadin.appsec.backend.model.AppSecData;
+import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
 
 /**
  * Event fired when a scan for vulnerabilities has been completed.
@@ -22,5 +27,23 @@ public class AppSecScanEvent extends EventObject {
     @Override
     public AppSecService getSource() {
         return (AppSecService) super.getSource();
+    }
+
+    /**
+     * Gets the list of new vulnerabilities found on this scan. A vulnerability
+     * is considered new if there is not a developer assessment data for that
+     * vulnerability.
+     *
+     * @return the list of new vulnerabilities
+     */
+    public List<VulnerabilityDTO> getNewVulnerabilities() {
+        return getSource().getVulnerabilities().stream()
+                .filter(this::newVulnerabilities).collect(Collectors.toList());
+    }
+
+    private boolean newVulnerabilities(VulnerabilityDTO vulnerability) {
+        String vulnerabilityId = vulnerability.getIdentifier();
+        AppSecData data = getSource().getData();
+        return !data.getVulnerabilities().containsKey(vulnerabilityId);
     }
 }

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (C) 2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.appsec.backend;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.appsec.backend.model.AppSecData;
+import com.vaadin.appsec.backend.model.AppSecData.Vulnerability;
+import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class AppSecScanEventTest {
+
+    private AppSecService service;
+
+    private AppSecData data;
+
+    private List<VulnerabilityDTO> vulnerabilities;
+
+    @Before
+    public void setup() {
+        service = Mockito.mock(AppSecService.class);
+        data = new AppSecData();
+        vulnerabilities = new ArrayList<>();
+        when(service.getData()).thenReturn(data);
+        when(service.getVulnerabilities()).thenReturn(vulnerabilities);
+    }
+
+    @Test
+    public void newVulnerabilties_noneExpected() {
+        vulnerabilities.add(new VulnerabilityDTO("foo"));
+        data.getVulnerabilities().put("foo", new Vulnerability());
+
+        AppSecScanEvent event = new AppSecScanEvent(service);
+        List<VulnerabilityDTO> newVulnerabilities = event
+                .getNewVulnerabilities();
+
+        assertEquals(0, newVulnerabilities.size());
+    }
+
+    @Test
+    public void newVulnerabilties_oneExpected() {
+        vulnerabilities.add(new VulnerabilityDTO("foo"));
+
+        AppSecScanEvent event = new AppSecScanEvent(service);
+        List<VulnerabilityDTO> newVulnerabilities = event
+                .getNewVulnerabilities();
+
+        assertEquals(1, newVulnerabilities.size());
+        assertEquals("foo", newVulnerabilities.get(0).getIdentifier());
+    }
+}


### PR DESCRIPTION
This adds a `getNewVulnerabilities()` method to `AppScanEvent` to get new vulnerabilities (i.e. without developer assessments) from the latest scan.

This can be used in the UI modules to decide whether or not to show the notification (or set a proper message).

Closes #39 