### PR TITLE
Simplify SBOM generation in demo apps

### DIFF
--- a/appsec-kit-demo-v7/README.md
+++ b/appsec-kit-demo-v7/README.md
@@ -1,5 +1,5 @@
-appsec-kit-demo-v7
-==============
+AppSec Kit Demo Vaadin 7
+========================
 
 A simple application for testing and demonstrating Vaadin AppSec Kit with Vaadin 7.
 
@@ -8,8 +8,5 @@ some vulnerabilities to show in the scan results.
 
 Workflow
 ========
-
-To build the application, run "mvn install". This needs to be run before jetty is
-started in order to generate the SBOM file. 
 
 To run the application, run "mvn jetty:run" and open http://localhost:8080/.

--- a/appsec-kit-demo-v7/README.md
+++ b/appsec-kit-demo-v7/README.md
@@ -9,7 +9,7 @@ some vulnerabilities to show in the scan results.
 Workflow
 ========
 
-To built the application, run "mvn install". This needs to be run before jetty is
+To build the application, run "mvn install". This needs to be run before jetty is
 started in order to generate the SBOM file. 
 
 To run the application, run "mvn jetty:run" and open http://localhost:8080/.

--- a/appsec-kit-demo-v7/pom.xml
+++ b/appsec-kit-demo-v7/pom.xml
@@ -143,7 +143,7 @@
 				<version>2.7.7</version>
 				<executions>
 					<execution>
-						<phase>prepare-package</phase>
+						<phase>generate-resources</phase>
 						<goals>
 							<goal>makeAggregateBom</goal>
 						</goals>
@@ -162,33 +162,9 @@
 					<outputReactorProjects>true</outputReactorProjects>
 					<outputFormat>json</outputFormat>
 					<outputName>bom</outputName>
-					<outputDirectory>${project.build.directory}/generated-resources/bom</outputDirectory>
+					<outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
 					<verbose>false</verbose>
 				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<id>copy-bom</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
-							<resources>
-								<resource>
-									<directory>${project.build.directory}/generated-resources/bom</directory>
-									<filtering>false</filtering>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/appsec-kit-demo-v8/README.md
+++ b/appsec-kit-demo-v8/README.md
@@ -1,5 +1,5 @@
-appsec-kit-demo-v8
-==============
+AppSec Kit Demo Vaadin 8
+========================
 
 A simple application for testing and demonstrating Vaadin AppSec Kit with Vaadin 8.
 
@@ -8,8 +8,5 @@ some vulnerabilities to show in the scan results.
 
 Workflow
 ========
-
-To build the application, run "mvn install". This needs to be run before jetty is
-started in order to generate the SBOM file. 
 
 To run the application, run "mvn jetty:run" and open http://localhost:8080/.

--- a/appsec-kit-demo-v8/README.md
+++ b/appsec-kit-demo-v8/README.md
@@ -9,7 +9,7 @@ some vulnerabilities to show in the scan results.
 Workflow
 ========
 
-To built the application, run "mvn install". This needs to be run before jetty is
+To build the application, run "mvn install". This needs to be run before jetty is
 started in order to generate the SBOM file. 
 
 To run the application, run "mvn jetty:run" and open http://localhost:8080/.

--- a/appsec-kit-demo-v8/pom.xml
+++ b/appsec-kit-demo-v8/pom.xml
@@ -143,7 +143,7 @@
 				<version>2.7.7</version>
 				<executions>
 					<execution>
-						<phase>prepare-package</phase>
+						<phase>generate-resources</phase>
 						<goals>
 							<goal>makeAggregateBom</goal>
 						</goals>
@@ -162,33 +162,9 @@
 					<outputReactorProjects>true</outputReactorProjects>
 					<outputFormat>json</outputFormat>
 					<outputName>bom</outputName>
-					<outputDirectory>${project.build.directory}/generated-resources/bom</outputDirectory>
+					<outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
 					<verbose>false</verbose>
 				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.0</version>
-				<executions>
-					<execution>
-						<id>copy-bom</id>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${project.build.outputDirectory}/resources</outputDirectory>
-							<resources>
-								<resource>
-									<directory>${project.build.directory}/generated-resources/bom</directory>
-									<filtering>false</filtering>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
With this change the `cyclonedx-maven-plugin` generates the SBOM file to the `${project.build.outputDirectory}/resources` immediately and there is no need for the `maven-resource-plugin` anymore.
Also, the `cyclonedx-maven-plugin` runs during the `generate-resources` phase now. With this there is no need to run `mvn install` before running the application with `maven jetty:run`