### PR TITLE
Add methods to get supported versions

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecService.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecService.java
@@ -71,6 +71,8 @@ public class AppSecService {
 
     private final AppSecDTOProvider dtoProvider;
 
+    private final GitHubService githubService;
+
     private AppSecConfiguration configuration;
 
     private AppSecData data;
@@ -90,6 +92,7 @@ public class AppSecService {
         osvService = new OpenSourceVulnerabilityService();
         vulnerabilityStore = new VulnerabilityStore(osvService, bomStore);
         dtoProvider = new AppSecDTOProvider(vulnerabilityStore, bomStore);
+        githubService = new GitHubService();
         this.configuration = configuration;
     }
 
@@ -106,6 +109,26 @@ public class AppSecService {
                     "Cannot parse the SBOM file: " + bomFilePath.toString(), e);
         }
         readOrCreateDataFile();
+    }
+
+    /**
+     * Gets the list of Vaadin Framework 7 versions for which the kit provides
+     * vulnerability assessments.
+     *
+     * @return the list of versions
+     */
+    public List<String> getSupportedFramework7Versions() {
+        return githubService.getFramework7Versions();
+    }
+
+    /**
+     * Gets the list of Vaadin Framework 8 versions for which the kit provides
+     * vulnerability assessments.
+     *
+     * @return the list of versions
+     */
+    public List<String> getSupportedFramework8Versions() {
+        return githubService.getFramework8Versions();
     }
 
     /**

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/GitHubService.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/GitHubService.java
@@ -1,0 +1,106 @@
+/*-
+ * Copyright (C) 2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.appsec.backend;
+
+import java.io.IOException;
+import java.net.URL;
+import java.text.Collator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import static java.util.regex.Pattern.compile;
+
+class GitHubService {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class GitHubRelease implements Comparable<GitHubRelease> {
+
+        @JsonProperty("tag_name")
+        private String tagName;
+
+        public String getTagName() {
+            return tagName;
+        }
+
+        public void setTagName(String name) {
+            this.tagName = name;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tagName);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof GitHubRelease)) {
+                return false;
+            }
+            GitHubRelease other = (GitHubRelease) obj;
+            return Objects.equals(tagName, other.tagName);
+        }
+
+        @Override
+        public int compareTo(GitHubRelease o) {
+            return Collator.getInstance().compare(tagName, o.tagName);
+        }
+    }
+
+    static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static final String FRAMEWORK_RELEASES_URI = "https://api.github.com/repos/vaadin/framework/releases";
+
+    static final Pattern FRAMEWORK_8_PATTERN = compile("^8\\.\\d+.\\d+$");
+
+    static final Pattern FRAMEWORK_7_PATTERN = compile("^7\\.\\d+.\\d+$");
+
+    static final long NUMBER_OF_LATEST_MAINTAINED_VERSIONS = 4;
+
+    private List<GitHubRelease> releasesCache;
+
+    List<String> getFramework8Versions() {
+        return getFrameworkVersions(FRAMEWORK_8_PATTERN);
+    }
+
+    List<String> getFramework7Versions() {
+        return getFrameworkVersions(FRAMEWORK_7_PATTERN);
+    }
+
+    private List<String> getFrameworkVersions(Pattern frameworkVersionPattern) {
+        return getReleasesFromGitHub().stream().map(GitHubRelease::getTagName)
+                .filter(frameworkVersionPattern.asPredicate())
+                .limit(NUMBER_OF_LATEST_MAINTAINED_VERSIONS)
+                .collect(Collectors.toList());
+    }
+
+    private List<GitHubRelease> getReleasesFromGitHub() {
+        if (releasesCache == null) {
+            ObjectReader listReader = MAPPER
+                    .readerForListOf(GitHubRelease.class);
+            try {
+                URL frameworkTagsUrl = new URL(FRAMEWORK_RELEASES_URI);
+                releasesCache = listReader.readValue(frameworkTagsUrl);
+            } catch (IOException e) {
+                throw new AppSecException(
+                        "Cannot get Vaadin releases from GitHub", e);
+            }
+        }
+        return releasesCache;
+    }
+}

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
@@ -1,0 +1,42 @@
+/*-
+ * Copyright (C) 2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.appsec.backend;
+
+import java.util.List;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+
+public class GitHubServiceTest {
+
+    private GitHubService service = new GitHubService();
+
+    @Test
+    public void getFramework7Versions() {
+        List<String> versions = service.getFramework7Versions();
+
+        assertEquals(GitHubService.NUMBER_OF_LATEST_MAINTAINED_VERSIONS,
+                versions.size());
+        versions.forEach(
+                version -> MatcherAssert.assertThat(version, startsWith("7.")));
+    }
+
+    @Test
+    public void getFramework8Versions() {
+        List<String> versions = service.getFramework8Versions();
+
+        assertEquals(GitHubService.NUMBER_OF_LATEST_MAINTAINED_VERSIONS,
+                versions.size());
+        versions.forEach(
+                version -> MatcherAssert.assertThat(version, startsWith("8.")));
+    }
+}


### PR DESCRIPTION
This adds two methods to `AppSecService` to get the latest Vaadin Framework versions for which the Security Team provides vulnerability assessments:

- `List<String> getSupportedFramework7Versions()`
- `List<String> getSupportedFramework8Versions()`

The list is fetched from GitHub API for releases and the last 4 entries per 7 or 8 versions are considered.