### PR TITLE
Notify of new vulnerabilities on scan events

### DIFF
--- a/appsec-kit-demo-v8/pom.xml
+++ b/appsec-kit-demo-v8/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<vaadin.version>8.8.0</vaadin.version>
 		<vaadin.plugin.version>8.8.0</vaadin.plugin.version>
-		<jetty.plugin.version>10.0.15</jetty.plugin.version>
+		<jetty.plugin.version>9.4.9.v20180320</jetty.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/appsec-kit-demo-v8/pom.xml
+++ b/appsec-kit-demo-v8/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<vaadin.version>8.8.0</vaadin.version>
 		<vaadin.plugin.version>8.8.0</vaadin.plugin.version>
-		<jetty.plugin.version>9.4.9.v20180320</jetty.plugin.version>
+		<jetty.plugin.version>10.0.15</jetty.plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/AppSecKitInitializer.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/AppSecKitInitializer.java
@@ -10,12 +10,12 @@
 
 package com.vaadin.appsec.v7.service;
 
-import javax.servlet.annotation.WebListener;
-import javax.servlet.http.HttpSessionEvent;
-import javax.servlet.http.HttpSessionListener;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +40,8 @@ public class AppSecKitInitializer implements HttpSessionListener {
 
     private static final List<String> initializedVaadinServiceNames = new CopyOnWriteArrayList<>();
 
+    private final NotificationInitializer notificationInitializer = new NotificationInitializer();
+
     @Override
     public synchronized void sessionCreated(HttpSessionEvent se) {
         VaadinService vaadinService = VaadinService.getCurrent();
@@ -55,7 +57,7 @@ public class AppSecKitInitializer implements HttpSessionListener {
                 LOGGER.info("AppSecService auto-scan scheduled every "
                         + appSecService.getConfiguration().getAutoScanInterval()
                                 .toString());
-                NotificationInitializer.serviceInit(vaadinService);
+                notificationInitializer.serviceInit(vaadinService);
                 initializedVaadinServiceNames.add(serviceName);
             } else {
                 LOGGER.info(

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/AppSecKitInitializer.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/AppSecKitInitializer.java
@@ -38,7 +38,7 @@ public class AppSecKitInitializer implements HttpSessionListener {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(AppSecKitInitializer.class);
 
-    private static final List<String> initializedVaadinServiceNames = new CopyOnWriteArrayList<>();
+    private final List<String> initializedVaadinServiceNames = new CopyOnWriteArrayList<>();
 
     private final NotificationInitializer notificationInitializer = new NotificationInitializer();
 

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
@@ -36,13 +36,6 @@ public class NotificationInitializer {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(NotificationInitializer.class);
 
-    /**
-     * Notification timeout (in ms). Set to 24 hours to essentially make it
-     * persistent until either the appsec link is clicked or the notification is
-     * dismissed.
-     */
-    private static final int NOTIFICATION_DELAY = 24 * 60 * 60 * 1000;
-
     private final Map<VaadinSession, Registration> scanEventRegistrations = new ConcurrentHashMap<>();
 
     void serviceInit(VaadinService service) {
@@ -88,7 +81,9 @@ public class NotificationInitializer {
         Notification n = new Notification("Vaadin AppSec Kit", msg,
                 Notification.Type.TRAY_NOTIFICATION);
         n.setPosition(Position.TOP_RIGHT);
-        n.setDelayMsec(NOTIFICATION_DELAY);
+        int delay = (int) AppSecService.getInstance().getConfiguration()
+                .getAutoScanInterval().toMillis();
+        n.setDelayMsec(delay);
         n.setHtmlContentAllowed(true);
         ui.access(() -> n.show(ui.getPage()));
     }

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
@@ -45,11 +45,11 @@ public class NotificationInitializer {
 
     private final Map<VaadinSession, Registration> scanEventRegistrations = new ConcurrentHashMap<>();
 
-    public void serviceInit(VaadinService service) {
+    void serviceInit(VaadinService service) {
         if (isDebugMode(service)) {
             service.addSessionInitListener(this::subscribeSessionToScanEvents);
             service.addSessionDestroyListener(this::removeSessionRegistration);
-            LOGGER.info("NotificationInitListener initialized.");
+            LOGGER.info("Subscribed to AppSec Kit scan events");
         }
     }
 

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/NotificationInitializer.java
@@ -90,7 +90,7 @@ public class NotificationInitializer {
         n.setPosition(Position.TOP_RIGHT);
         n.setDelayMsec(NOTIFICATION_DELAY);
         n.setHtmlContentAllowed(true);
-        n.show(ui.getPage());
+        ui.access(() -> n.show(ui.getPage()));
     }
 
     private boolean isSessionOpen(VaadinSession session) {

--- a/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/AppSecKitInitializerTest.java
+++ b/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/AppSecKitInitializerTest.java
@@ -16,7 +16,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-public class AppSecServiceInitListenerTest extends AbstractAppSecKitTest {
+public class AppSecKitInitializerTest extends AbstractAppSecKitTest {
 
     @Test
     public void debugMode_kitInitialized() {

--- a/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/NotificationInitializerTest.java
+++ b/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/NotificationInitializerTest.java
@@ -12,23 +12,31 @@ package com.vaadin.appsec.v7.service;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-public class NoticationInitListenerTest extends AbstractAppSecKitTest {
+public class NotificationInitializerTest extends AbstractAppSecKitTest {
+
+    private NotificationInitializer noitificationInitializer;
+
+    @Before
+    public void setup() {
+        noitificationInitializer = new NotificationInitializer();
+    }
 
     @Test
     public void testNotificationInitializer_initsProperly_debugMode() {
         ListAppender<ILoggingEvent> logAppender = createListAppender(
                 NotificationInitializer.class.getName());
 
-        NotificationInitializer.serviceInit(service);
+        noitificationInitializer.serviceInit(service);
 
-        Assert.assertEquals("Unexpected count of log messages. ", 1,
+        assertEquals("Unexpected count of log messages. ", 1,
                 logAppender.list.size());
-        Assert.assertEquals("NotificationInitListener initialization failed.",
+        assertEquals("NotificationInitListener initialization failed.",
                 "NotificationInitListener initialized.",
                 logAppender.list.get(0).getMessage());
     }
@@ -41,9 +49,9 @@ public class NoticationInitListenerTest extends AbstractAppSecKitTest {
         ListAppender<ILoggingEvent> logAppender = createListAppender(
                 NotificationInitializer.class.getName());
 
-        NotificationInitializer.serviceInit(service);
+        noitificationInitializer.serviceInit(service);
 
-        Assert.assertEquals("Unexpected count of log messages. ", 0,
+        assertEquals("Unexpected count of log messages. ", 0,
                 logAppender.list.size());
     }
 }

--- a/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/NotificationInitializerTest.java
+++ b/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/NotificationInitializerTest.java
@@ -37,7 +37,7 @@ public class NotificationInitializerTest extends AbstractAppSecKitTest {
         assertEquals("Unexpected count of log messages. ", 1,
                 logAppender.list.size());
         assertEquals("NotificationInitListener initialization failed.",
-                "NotificationInitListener initialized.",
+                "Subscribed to AppSec Kit scan events",
                 logAppender.list.get(0).getMessage());
     }
 

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
@@ -93,7 +93,7 @@ public class NotificationInitListener extends AbstractInitListener {
         n.setPosition(Position.TOP_RIGHT);
         n.setDelayMsec(NOTIFICATION_DELAY);
         n.setHtmlContentAllowed(true);
-        n.show(ui.getPage());
+        ui.access(() -> n.show(ui.getPage()));
     }
 
     private boolean isSessionOpen(VaadinSession session) {

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
@@ -37,13 +37,6 @@ public class NotificationInitListener extends AbstractInitListener {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(NotificationInitListener.class);
 
-    /**
-     * Notification timeout (in ms). Set to 24 hours to essentially make it
-     * persistent until either the appsec link is clicked or the notification is
-     * dismissed.
-     */
-    private static final int NOTIFICATION_DELAY = 24 * 60 * 60 * 1000;
-
     private final Map<VaadinSession, Registration> scanEventRegistrations = new ConcurrentHashMap<>();
 
     @Override
@@ -91,7 +84,9 @@ public class NotificationInitListener extends AbstractInitListener {
         Notification n = new Notification("Vaadin AppSec Kit", msg,
                 Notification.Type.TRAY_NOTIFICATION);
         n.setPosition(Position.TOP_RIGHT);
-        n.setDelayMsec(NOTIFICATION_DELAY);
+        int delay = (int) AppSecService.getInstance().getConfiguration()
+                .getAutoScanInterval().toMillis();
+        n.setDelayMsec(delay);
         n.setHtmlContentAllowed(true);
         ui.access(() -> n.show(ui.getPage()));
     }

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
@@ -52,7 +52,7 @@ public class NotificationInitListener extends AbstractInitListener {
         if (isDebugMode(service)) {
             service.addSessionInitListener(this::subscribeSessionToScanEvents);
             service.addSessionDestroyListener(this::removeSessionRegistration);
-            LOGGER.info("NotificationInitListener initialized.");
+            LOGGER.info("Subscribed to AppSec Kit scan events");
         }
     }
 

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/NotificationInitListener.java
@@ -9,15 +9,19 @@
 
 package com.vaadin.appsec.v8.service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.appsec.backend.AppSecService;
+import com.vaadin.appsec.backend.Registration;
 import com.vaadin.appsec.v8.ui.AppSecUI;
 import com.vaadin.appsec.v8.ui.AppSecUIProvider;
 import com.vaadin.server.ServiceInitEvent;
+import com.vaadin.server.SessionDestroyEvent;
+import com.vaadin.server.SessionInitEvent;
 import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.shared.Position;
@@ -33,13 +37,6 @@ public class NotificationInitListener extends AbstractInitListener {
     private static final Logger LOGGER = LoggerFactory
             .getLogger(NotificationInitListener.class);
 
-    private static final String NOTIFIED_UIS_SESSION_PARAM = "vaadin-appsec-kit-notified-uis";
-    /**
-     * New UI instance check interval (in ms). Determines how often the session
-     * is checked for new UI instances which might need a notification shown.
-     */
-    private static final int NOTIFICATION_CHECK_INTERVAL = 5000;
-
     /**
      * Notification timeout (in ms). Set to 24 hours to essentially make it
      * persistent until either the appsec link is clicked or the notification is
@@ -47,66 +44,44 @@ public class NotificationInitListener extends AbstractInitListener {
      */
     private static final int NOTIFICATION_DELAY = 24 * 60 * 60 * 1000;
 
+    private final Map<VaadinSession, Registration> scanEventRegistrations = new ConcurrentHashMap<>();
+
     @Override
     public void serviceInit(ServiceInitEvent event) {
-        VaadinService vaadinService = event.getSource();
-        if (isDebugMode(vaadinService)) {
-            vaadinService.addSessionInitListener(e -> {
-                e.getSession().addUIProvider(new AppSecUIProvider());
-                createNotificationThread(e.getSession()).start();
-            });
+        VaadinService service = event.getSource();
+        if (isDebugMode(service)) {
+            service.addSessionInitListener(this::subscribeSessionToScanEvents);
+            service.addSessionDestroyListener(this::removeSessionRegistration);
             LOGGER.info("NotificationInitListener initialized.");
         }
     }
 
-    private Thread createNotificationThread(final VaadinSession session) {
-        return new Thread(() -> {
-            try {
-                LOGGER.debug(
-                        "NotificationInitListener notification thread initialized.");
-
-                Thread.sleep(NOTIFICATION_CHECK_INTERVAL);
-
-                while (isSessionOpen(session)) {
-                    session.access(() -> {
-                        session.getUIs()
-                                .forEach(ui -> notifyUiIfNeeded(session, ui));
-                    });
-                    Thread.sleep(NOTIFICATION_CHECK_INTERVAL);
-                }
-            } catch (InterruptedException e) {
-                // NOP
-            }
-        });
+    private void removeSessionRegistration(SessionDestroyEvent e) {
+        VaadinSession session = e.getSession();
+        Registration registration = scanEventRegistrations.get(session);
+        if (registration != null) {
+            registration.remove();
+        }
     }
 
-    @SuppressWarnings("unchecked")
-    private void notifyUiIfNeeded(VaadinSession session, UI ui) {
-        if (ui instanceof AppSecUI) {
-            return;
-        }
-
-        List<Integer> notifiedUIs;
-        Object notifiedUIsFromSession = session
-                .getAttribute(NOTIFIED_UIS_SESSION_PARAM);
-
-        try {
-            notifiedUIs = new ArrayList<>(
-                    (List<Integer>) notifiedUIsFromSession);
-        } catch (RuntimeException e) {
-            notifiedUIs = new ArrayList<>();
-        }
-
-        // Notify UI
-        if (!notifiedUIs.contains(ui.getUIId())) {
-            doNotifyUI(ui);
-            notifiedUIs.add(ui.getUIId());
-        }
-
-        session.setAttribute(NOTIFIED_UIS_SESSION_PARAM, notifiedUIs);
+    private void subscribeSessionToScanEvents(SessionInitEvent e) {
+        VaadinSession session = e.getSession();
+        session.addUIProvider(new AppSecUIProvider());
+        AppSecService appSecService = AppSecService.getInstance();
+        Registration scanEventRegistration = appSecService
+                .addScanEventListener(scanEvent -> {
+                    int newVulns = scanEvent.getNewVulnerabilities().size();
+                    if (isSessionOpen(session) && newVulns > 0) {
+                        session.getUIs().forEach(this::doNotifyUI);
+                    }
+                });
+        scanEventRegistrations.put(session, scanEventRegistration);
     }
 
     private void doNotifyUI(UI ui) {
+        if (ui instanceof AppSecUI) {
+            return;
+        }
         String link = "<a href=\"?"
                 + AppSecUIProvider.VAADIN_APPSEC_KIT_URL_PARAM
                 + "\" target=\"_blank\">here</a>";

--- a/appsec-kit-v8/src/test/java/com/vaadin/appsec/v8/service/NotificationInitListenerTest.java
+++ b/appsec-kit-v8/src/test/java/com/vaadin/appsec/v8/service/NotificationInitListenerTest.java
@@ -18,7 +18,7 @@ import com.vaadin.server.ServiceInitEvent;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
-public class NoticationInitListenerTest extends AbstractAppSecKitTest {
+public class NotificationInitListenerTest extends AbstractAppSecKitTest {
 
     @Test
     public void testVulnStoreInit_initsProperly_debugMode() {
@@ -34,7 +34,7 @@ public class NoticationInitListenerTest extends AbstractAppSecKitTest {
         assertEquals("Unexpected count of log messages. ", 1,
                 logAppender.list.size());
         assertEquals("NotificationInitListener initialization failed.",
-                "NotificationInitListener initialized.",
+                "Subscribed to AppSec Kit scan events",
                 logAppender.list.get(0).getMessage());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.surefire.version>2.22.2</maven.surefire.version>
         <maven.formatter.version>2.16.0</maven.formatter.version>
-        <jackson.version>2.15.2</jackson.version>
+        <jackson.version>2.14.3</jackson.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This replaces the sleeping notification thread with proper scan event listeners for each session, by:

- [x] register a session-init listener to subscribe to the scan event
- [x] register a session-destroy listener to clear the event subscription