### PR TITLE
Exclude demo modules from release

### DIFF
--- a/appsec-kit-v7/pom.xml
+++ b/appsec-kit-v7/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <vaadin.version>7.7.0</vaadin.version>
+        <vaadin7.version>7.7.0</vaadin7.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
-            <version>${vaadin.version}</version>
+            <version>${vaadin7.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/appsec-kit-v8/pom.xml
+++ b/appsec-kit-v8/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <vaadin.version>8.0.0</vaadin.version>
+        <vaadin8.version>8.0.0</vaadin8.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
-            <version>${vaadin.version}</version>
+            <version>${vaadin8.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,9 @@
     </licenses>
 
     <modules>
-        <module>appsec-kit-demo-v8</module>
-        <module>appsec-kit-demo-v7</module>
         <module>appsec-kit-backend</module>
-        <module>appsec-kit-v8</module>
         <module>appsec-kit-v7</module>
+        <module>appsec-kit-v8</module>
     </modules>
 
     <properties>
@@ -127,4 +125,18 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>demo</id>
+            <activation>
+                <property>
+                    <name>!release</name>
+                </property>
+            </activation>
+            <modules>
+                <module>appsec-kit-demo-v7</module>
+                <module>appsec-kit-demo-v8</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This excludes the demo modules from release, i.e. if the `release` property is defined. It also change property names in V7 and V8 modules to be able to specify versions individually per each module.