### PR TITLE
Rename classes to conform common naming practices

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -85,8 +85,7 @@ class AppSecDTOProvider {
                         .findFirst().orElse(null);
                 if (dependencyDTO != null) {
                     String id = getVulnerabilityId(v);
-                    Vulnerability vulnerabilityDTO = new Vulnerability(
-                            id);
+                    Vulnerability vulnerabilityDTO = new Vulnerability(id);
                     vulnerabilityDTO.setDependency(dependencyDTO);
                     vulnerabilityDTOS.add(vulnerabilityDTO);
                     vulnerabilityDTO.setDatePublished(v.getPublished());

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecScanEvent.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecScanEvent.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.vaadin.appsec.backend.model.AppSecData;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 
 /**
  * Event fired when a scan for vulnerabilities has been completed.
@@ -36,12 +36,12 @@ public class AppSecScanEvent extends EventObject {
      *
      * @return the list of new vulnerabilities
      */
-    public List<VulnerabilityDTO> getNewVulnerabilities() {
+    public List<Vulnerability> getNewVulnerabilities() {
         return getSource().getVulnerabilities().stream()
                 .filter(this::newVulnerabilities).collect(Collectors.toList());
     }
 
-    private boolean newVulnerabilities(VulnerabilityDTO vulnerability) {
+    private boolean newVulnerabilities(Vulnerability vulnerability) {
         String vulnerabilityId = vulnerability.getIdentifier();
         AppSecData data = getSource().getData();
         return !data.getVulnerabilities().containsKey(vulnerabilityId);

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecService.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecService.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.appsec.backend.model.AppSecData;
 import com.vaadin.appsec.backend.model.analysis.VulnerabilityAnalysis;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 
 /**
  * Service that provides access to all AppSec Kit features, such as
@@ -225,7 +225,7 @@ public class AppSecService {
      *
      * @return the list of dependencies
      */
-    public List<DependencyDTO> getDependencies() {
+    public List<Dependency> getDependencies() {
         return dtoProvider.getDependencies();
     }
 
@@ -236,7 +236,7 @@ public class AppSecService {
      *
      * @return the list of vulnerabilities
      */
-    public List<VulnerabilityDTO> getVulnerabilities() {
+    public List<Vulnerability> getVulnerabilities() {
         return dtoProvider.getVulnerabilities();
     }
 

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/AppSecData.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/AppSecData.java
@@ -185,7 +185,8 @@ public class AppSecData implements Serializable {
      * @param vulnerabilities
      *            the vulnerabilities
      */
-    public void setVulnerabilities(Map<String, VulnerabilityAssessment> vulnerabilities) {
+    public void setVulnerabilities(
+            Map<String, VulnerabilityAssessment> vulnerabilities) {
         this.vulnerabilities = vulnerabilities;
     }
 }

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/AppSecData.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/AppSecData.java
@@ -43,7 +43,7 @@ public class AppSecData implements Serializable {
     /**
      * Data object to store the analysis status of a single vulnerability.
      */
-    public static class Vulnerability {
+    public static class VulnerabilityAssessment {
 
         private String id;
 
@@ -139,17 +139,17 @@ public class AppSecData implements Serializable {
             if (this == obj) {
                 return true;
             }
-            if (!(obj instanceof Vulnerability)) {
+            if (!(obj instanceof VulnerabilityAssessment)) {
                 return false;
             }
-            Vulnerability other = (Vulnerability) obj;
+            VulnerabilityAssessment other = (VulnerabilityAssessment) obj;
             return Objects.equals(id, other.id);
         }
     }
 
     private Instant lastScan;
 
-    private Map<String, Vulnerability> vulnerabilities = new HashMap<>();
+    private Map<String, VulnerabilityAssessment> vulnerabilities = new HashMap<>();
 
     /**
      * Gets the timestamp of the most recent vulnerability scan.
@@ -175,7 +175,7 @@ public class AppSecData implements Serializable {
      *
      * @return the vulnerabilities
      */
-    public Map<String, Vulnerability> getVulnerabilities() {
+    public Map<String, VulnerabilityAssessment> getVulnerabilities() {
         return vulnerabilities;
     }
 
@@ -185,7 +185,7 @@ public class AppSecData implements Serializable {
      * @param vulnerabilities
      *            the vulnerabilities
      */
-    public void setVulnerabilities(Map<String, Vulnerability> vulnerabilities) {
+    public void setVulnerabilities(Map<String, VulnerabilityAssessment> vulnerabilities) {
         this.vulnerabilities = vulnerabilities;
     }
 }

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityAnalysis.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityAnalysis.java
@@ -25,14 +25,16 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 public class VulnerabilityAnalysis implements Serializable {
 
-    static class MapDeserializer extends JsonDeserializer<VulnerabilityDetails> {
+    static class MapDeserializer
+            extends JsonDeserializer<VulnerabilityDetails> {
 
         @Override
         public VulnerabilityDetails deserialize(JsonParser p,
                 DeserializationContext ctxt)
                 throws IOException, JsonProcessingException {
             String id = ctxt.getParser().getCurrentName();
-            VulnerabilityDetails vulnerability = p.readValueAs(VulnerabilityDetails.class);
+            VulnerabilityDetails vulnerability = p
+                    .readValueAs(VulnerabilityDetails.class);
             vulnerability.setId(id);
             return vulnerability;
         }

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityAnalysis.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityAnalysis.java
@@ -25,21 +25,21 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  */
 public class VulnerabilityAnalysis implements Serializable {
 
-    static class MapDeserializer extends JsonDeserializer<Vulnerability> {
+    static class MapDeserializer extends JsonDeserializer<VulnerabilityDetails> {
 
         @Override
-        public Vulnerability deserialize(JsonParser p,
+        public VulnerabilityDetails deserialize(JsonParser p,
                 DeserializationContext ctxt)
                 throws IOException, JsonProcessingException {
             String id = ctxt.getParser().getCurrentName();
-            Vulnerability vulnerability = p.readValueAs(Vulnerability.class);
+            VulnerabilityDetails vulnerability = p.readValueAs(VulnerabilityDetails.class);
             vulnerability.setId(id);
             return vulnerability;
         }
     }
 
     @JsonDeserialize(contentUsing = MapDeserializer.class)
-    private Map<String, Vulnerability> vulnerabilities = new HashMap<>();
+    private Map<String, VulnerabilityDetails> vulnerabilities = new HashMap<>();
 
     /**
      * Gets the list of known vulnerabilities the Vaadin Security Team has
@@ -47,11 +47,11 @@ public class VulnerabilityAnalysis implements Serializable {
      *
      * @return a map with information about vulnerability assessments
      */
-    public Map<String, Vulnerability> getVulnerabilities() {
+    public Map<String, VulnerabilityDetails> getVulnerabilities() {
         return vulnerabilities;
     }
 
-    void setVulnerabilities(Map<String, Vulnerability> vulnerabilities) {
+    void setVulnerabilities(Map<String, VulnerabilityDetails> vulnerabilities) {
         this.vulnerabilities = vulnerabilities;
     }
 

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityDetails.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/analysis/VulnerabilityDetails.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * dependency that brings the vulnerability and assessment for Vaadin modules
  * depending on that dependency in the maintained versions.
  */
-public class Vulnerability implements Serializable {
+public class VulnerabilityDetails implements Serializable {
 
     static class MapDeserializer extends JsonDeserializer<Assessment> {
 
@@ -97,10 +97,10 @@ public class Vulnerability implements Serializable {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Vulnerability)) {
+        if (!(obj instanceof VulnerabilityDetails)) {
             return false;
         }
-        Vulnerability other = (Vulnerability) obj;
+        VulnerabilityDetails other = (VulnerabilityDetails) obj;
         return Objects.equals(id, other.id);
     }
 

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 /**
  * DTO for a dependency instance, used in the UI.
  */
-public class DependencyDTO {
+public class Dependency {
 
     private String group;
     private String name;
@@ -36,7 +36,7 @@ public class DependencyDTO {
      * @param version
      *            the version
      */
-    public DependencyDTO(@NotNull String group, @NotNull String name,
+    public Dependency(@NotNull String group, @NotNull String name,
             @NotNull String version) {
         this.group = group;
         this.name = name;
@@ -106,7 +106,7 @@ public class DependencyDTO {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        DependencyDTO that = (DependencyDTO) o;
+        Dependency that = (Dependency) o;
         return Objects.equals(group, that.group)
                 && Objects.equals(name, that.name)
                 && Objects.equals(version, that.version);

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Vulnerability.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Vulnerability.java
@@ -20,10 +20,10 @@ import com.vaadin.appsec.backend.model.AppSecData;
 /**
  * DTO for a vulnerability instance, used in the UI.
  */
-public class VulnerabilityDTO {
+public class Vulnerability {
 
     private String identifier;
-    private DependencyDTO dependency;
+    private Dependency dependency;
     private String vaadinAnalysis;
     private AppSecData.VulnerabilityStatus developerStatus;
     private String developerAnalysis;
@@ -40,7 +40,7 @@ public class VulnerabilityDTO {
      * @param identifier
      *            the identifier
      */
-    public VulnerabilityDTO(@NotNull String identifier) {
+    public Vulnerability(@NotNull String identifier) {
         this.identifier = identifier;
     }
 
@@ -58,7 +58,7 @@ public class VulnerabilityDTO {
      *
      * @return the dependency
      */
-    public DependencyDTO getDependency() {
+    public Dependency getDependency() {
         return dependency;
     }
 
@@ -68,7 +68,7 @@ public class VulnerabilityDTO {
      * @param dependency
      *            the dependency
      */
-    public void setDependency(DependencyDTO dependency) {
+    public void setDependency(Dependency dependency) {
         this.dependency = dependency;
     }
 
@@ -175,7 +175,7 @@ public class VulnerabilityDTO {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        VulnerabilityDTO that = (VulnerabilityDTO) o;
+        Vulnerability that = (Vulnerability) o;
         return identifier.equals(that.identifier)
                 && Objects.equals(dependency, that.dependency);
     }

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
@@ -17,8 +17,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 
 public class AppSecDTOProviderTest {
 
@@ -53,7 +53,7 @@ public class AppSecDTOProviderTest {
     public void testGetDependencies() {
         AppSecDTOProvider dtoProvider = new AppSecDTOProvider(
                 vulnerabilityStore, bomStore);
-        List<DependencyDTO> dependencies = dtoProvider.getDependencies();
+        List<Dependency> dependencies = dtoProvider.getDependencies();
 
         Assert.assertEquals("Mismatch in expected dependency count.", 2,
                 dependencies.size());
@@ -63,7 +63,7 @@ public class AppSecDTOProviderTest {
     public void testGetVulnerabilities() {
         AppSecDTOProvider dtoProvider = new AppSecDTOProvider(
                 vulnerabilityStore, bomStore);
-        List<VulnerabilityDTO> vulnerabilities = dtoProvider
+        List<Vulnerability> vulnerabilities = dtoProvider
                 .getVulnerabilities();
 
         Assert.assertEquals("Mismatch in expected vulnerability count.", 3,

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
@@ -63,8 +63,7 @@ public class AppSecDTOProviderTest {
     public void testGetVulnerabilities() {
         AppSecDTOProvider dtoProvider = new AppSecDTOProvider(
                 vulnerabilityStore, bomStore);
-        List<Vulnerability> vulnerabilities = dtoProvider
-                .getVulnerabilities();
+        List<Vulnerability> vulnerabilities = dtoProvider.getVulnerabilities();
 
         Assert.assertEquals("Mismatch in expected vulnerability count.", 3,
                 vulnerabilities.size());

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
@@ -16,8 +16,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.appsec.backend.model.AppSecData;
-import com.vaadin.appsec.backend.model.AppSecData.Vulnerability;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.AppSecData.VulnerabilityAssessment;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -28,7 +28,7 @@ public class AppSecScanEventTest {
 
     private AppSecData data;
 
-    private List<VulnerabilityDTO> vulnerabilities;
+    private List<Vulnerability> vulnerabilities;
 
     @Before
     public void setup() {
@@ -41,11 +41,11 @@ public class AppSecScanEventTest {
 
     @Test
     public void newVulnerabilties_noneExpected() {
-        vulnerabilities.add(new VulnerabilityDTO("foo"));
-        data.getVulnerabilities().put("foo", new Vulnerability());
+        vulnerabilities.add(new Vulnerability("foo"));
+        data.getVulnerabilities().put("foo", new VulnerabilityAssessment());
 
         AppSecScanEvent event = new AppSecScanEvent(service);
-        List<VulnerabilityDTO> newVulnerabilities = event
+        List<Vulnerability> newVulnerabilities = event
                 .getNewVulnerabilities();
 
         assertEquals(0, newVulnerabilities.size());
@@ -53,10 +53,10 @@ public class AppSecScanEventTest {
 
     @Test
     public void newVulnerabilties_oneExpected() {
-        vulnerabilities.add(new VulnerabilityDTO("foo"));
+        vulnerabilities.add(new Vulnerability("foo"));
 
         AppSecScanEvent event = new AppSecScanEvent(service);
-        List<VulnerabilityDTO> newVulnerabilities = event
+        List<Vulnerability> newVulnerabilities = event
                 .getNewVulnerabilities();
 
         assertEquals(1, newVulnerabilities.size());

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecScanEventTest.java
@@ -45,8 +45,7 @@ public class AppSecScanEventTest {
         data.getVulnerabilities().put("foo", new VulnerabilityAssessment());
 
         AppSecScanEvent event = new AppSecScanEvent(service);
-        List<Vulnerability> newVulnerabilities = event
-                .getNewVulnerabilities();
+        List<Vulnerability> newVulnerabilities = event.getNewVulnerabilities();
 
         assertEquals(0, newVulnerabilities.size());
     }
@@ -56,8 +55,7 @@ public class AppSecScanEventTest {
         vulnerabilities.add(new Vulnerability("foo"));
 
         AppSecScanEvent event = new AppSecScanEvent(service);
-        List<Vulnerability> newVulnerabilities = event
-                .getNewVulnerabilities();
+        List<Vulnerability> newVulnerabilities = event.getNewVulnerabilities();
 
         assertEquals(1, newVulnerabilities.size());
         assertEquals("foo", newVulnerabilities.get(0).getIdentifier());

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecServiceTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.vaadin.appsec.backend.model.AppSecData;
-import com.vaadin.appsec.backend.model.AppSecData.Vulnerability;
+import com.vaadin.appsec.backend.model.AppSecData.VulnerabilityAssessment;
 import com.vaadin.appsec.backend.model.AppSecData.VulnerabilityStatus;
 
 import static org.junit.Assert.assertEquals;
@@ -149,7 +149,7 @@ public class AppSecServiceTest {
         Instant now = Instant.now();
         AppSecData data = new AppSecData();
         data.setLastScan(now);
-        Vulnerability vuln = new Vulnerability();
+        VulnerabilityAssessment vuln = new VulnerabilityAssessment();
         vuln.setId("CVE-XXX");
         vuln.setStatus(VulnerabilityStatus.NOT_SET);
         vuln.setUpdated(now);

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
@@ -63,8 +63,9 @@ public class GitHubServiceTest {
         VulnerabilityAnalysis vulnerabilityAnalysis = service
                 .getVulnerabilityAnalysis();
 
-        VulnerabilityDetails vulnerability = vulnerabilityAnalysis.getVulnerabilities()
-                .entrySet().stream().findFirst().get().getValue();
+        VulnerabilityDetails vulnerability = vulnerabilityAnalysis
+                .getVulnerabilities().entrySet().stream().findFirst().get()
+                .getValue();
 
         assertEquals("org.acme:foobar",
                 vulnerability.getDependency().getName());

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/GitHubServiceTest.java
@@ -15,7 +15,7 @@ import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import com.vaadin.appsec.backend.model.analysis.Assessment;
-import com.vaadin.appsec.backend.model.analysis.Vulnerability;
+import com.vaadin.appsec.backend.model.analysis.VulnerabilityDetails;
 import com.vaadin.appsec.backend.model.analysis.VulnerabilityAnalysis;
 
 import static org.hamcrest.CoreMatchers.startsWith;
@@ -63,7 +63,7 @@ public class GitHubServiceTest {
         VulnerabilityAnalysis vulnerabilityAnalysis = service
                 .getVulnerabilityAnalysis();
 
-        Vulnerability vulnerability = vulnerabilityAnalysis.getVulnerabilities()
+        VulnerabilityDetails vulnerability = vulnerabilityAnalysis.getVulnerabilities()
                 .entrySet().stream().findFirst().get().getValue();
 
         assertEquals("org.acme:foobar",

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/DependenciesTab.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/DependenciesTab.java
@@ -13,7 +13,7 @@ package com.vaadin.appsec.v7.ui.content;
 import java.util.stream.Collectors;
 
 import com.vaadin.appsec.backend.AppSecService;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
@@ -66,7 +66,7 @@ public class DependenciesTab extends AbstractAppSecContent {
             @Override
             public boolean passesFilter(Object itemId, Item item)
                     throws UnsupportedOperationException {
-                DependencyDTO dependencyDTO = (DependencyDTO) itemId;
+                Dependency dependencyDTO = (Dependency) itemId;
                 if (groupFilter != null
                         && !groupFilter.equals(dependencyDTO.getGroup())) {
                     return false;
@@ -90,8 +90,8 @@ public class DependenciesTab extends AbstractAppSecContent {
         grid = new Grid();
         grid.setSizeFull();
 
-        BeanItemContainer<DependencyDTO> cont = new BeanItemContainer<>(
-                DependencyDTO.class);
+        BeanItemContainer<Dependency> cont = new BeanItemContainer<>(
+                Dependency.class);
         grid.setContainerDataSource(cont);
         grid.removeAllColumns();
         grid.addColumn("name");
@@ -112,14 +112,14 @@ public class DependenciesTab extends AbstractAppSecContent {
 
         grid.addItemClickListener(e -> {
             if (e.isDoubleClick()) {
-                parent.showVulnerabilitiesTabFor((DependencyDTO) e.getItemId());
+                parent.showVulnerabilitiesTabFor((Dependency) e.getItemId());
             }
         });
     }
 
     @SuppressWarnings("unchecked")
-    private BeanItemContainer<DependencyDTO> getContainer() {
-        return (BeanItemContainer<DependencyDTO>) grid.getContainerDataSource();
+    private BeanItemContainer<Dependency> getContainer() {
+        return (BeanItemContainer<Dependency>) grid.getContainerDataSource();
     }
 
     public void refresh() {
@@ -129,7 +129,7 @@ public class DependenciesTab extends AbstractAppSecContent {
 
         BeanItemContainer<String> groupsCont = new BeanItemContainer<>(
                 String.class);
-        getContainer().getItemIds().stream().map(DependencyDTO::getGroup)
+        getContainer().getItemIds().stream().map(Dependency::getGroup)
                 .collect(Collectors.toSet()).forEach(groupsCont::addBean);
         group.setContainerDataSource(groupsCont);
     }

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/MainView.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/MainView.java
@@ -15,7 +15,7 @@ import java.util.Date;
 
 import com.vaadin.appsec.backend.AppSecService;
 import com.vaadin.appsec.backend.Registration;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
@@ -104,7 +104,7 @@ public class MainView extends AbstractAppSecContent {
                 : formatter.format(Date.from(lastScan))));
     }
 
-    void showVulnerabilitiesTabFor(DependencyDTO item) {
+    void showVulnerabilitiesTabFor(Dependency item) {
         tabSheet.setSelectedTab(vulnerabilitiesTab);
         vulnerabilitiesTab.filterOn(item);
     }

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilitiesTab.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilitiesTab.java
@@ -76,8 +76,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
     protected void applyFilters() {
         getContainer().removeAllContainerFilters();
 
-        final Dependency dependencyFilter = (Dependency) dependency
-                .getValue();
+        final Dependency dependencyFilter = (Dependency) dependency.getValue();
         final SeverityLevel severityFilter = (SeverityLevel) severity
                 .getValue();
 
@@ -159,8 +158,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
 
     @SuppressWarnings("unchecked")
     private BeanItemContainer<Vulnerability> getContainer() {
-        return (BeanItemContainer<Vulnerability>) grid
-                .getContainerDataSource();
+        return (BeanItemContainer<Vulnerability>) grid.getContainerDataSource();
     }
 
     @Override
@@ -173,8 +171,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
 
         BeanItemContainer<Dependency> depsCont = new BeanItemContainer<>(
                 Dependency.class);
-        getContainer().getItemIds().stream()
-                .map(Vulnerability::getDependency)
+        getContainer().getItemIds().stream().map(Vulnerability::getDependency)
                 .collect(Collectors.toSet()).forEach(depsCont::addBean);
         dependency.setContainerDataSource(depsCont);
     }

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilitiesTab.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilitiesTab.java
@@ -14,9 +14,9 @@ import java.util.stream.Collectors;
 
 import com.vaadin.appsec.backend.AppSecService;
 import com.vaadin.appsec.backend.model.AppSecData;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 import com.vaadin.data.Container;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.BeanItemContainer;
@@ -76,7 +76,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
     protected void applyFilters() {
         getContainer().removeAllContainerFilters();
 
-        final DependencyDTO dependencyFilter = (DependencyDTO) dependency
+        final Dependency dependencyFilter = (Dependency) dependency
                 .getValue();
         final SeverityLevel severityFilter = (SeverityLevel) severity
                 .getValue();
@@ -90,7 +90,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
             @Override
             public boolean passesFilter(Object itemId, Item item)
                     throws UnsupportedOperationException {
-                VulnerabilityDTO vulnerabilityDTO = (VulnerabilityDTO) itemId;
+                Vulnerability vulnerabilityDTO = (Vulnerability) itemId;
                 if (dependencyFilter != null && !dependencyFilter
                         .equals(vulnerabilityDTO.getDependency())) {
                     return false;
@@ -119,8 +119,8 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
         grid = new Grid();
         grid.setSizeFull();
 
-        BeanItemContainer<VulnerabilityDTO> cont = new BeanItemContainer<>(
-                VulnerabilityDTO.class);
+        BeanItemContainer<Vulnerability> cont = new BeanItemContainer<>(
+                Vulnerability.class);
         grid.setContainerDataSource(cont);
         grid.removeAllColumns();
         grid.addColumn("identifier");
@@ -142,7 +142,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
 
         grid.addItemClickListener(event -> {
             if (event.isDoubleClick()) {
-                showVulnerabilityDetails((VulnerabilityDTO) event.getItemId());
+                showVulnerabilityDetails((Vulnerability) event.getItemId());
             }
         });
 
@@ -152,29 +152,29 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
         getMainContent().setComponentAlignment(showDetails,
                 Alignment.BOTTOM_RIGHT);
         showDetails.addClickListener(e -> showVulnerabilityDetails(
-                (VulnerabilityDTO) grid.getSelectedRows().iterator().next()));
+                (Vulnerability) grid.getSelectedRows().iterator().next()));
         grid.addSelectionListener(
                 e -> showDetails.setEnabled(e.getSelected().size() != 0));
     }
 
     @SuppressWarnings("unchecked")
-    private BeanItemContainer<VulnerabilityDTO> getContainer() {
-        return (BeanItemContainer<VulnerabilityDTO>) grid
+    private BeanItemContainer<Vulnerability> getContainer() {
+        return (BeanItemContainer<Vulnerability>) grid
                 .getContainerDataSource();
     }
 
     @Override
     public void refresh() {
-        BeanItemContainer<VulnerabilityDTO> container = new BeanItemContainer<>(
-                VulnerabilityDTO.class);
+        BeanItemContainer<Vulnerability> container = new BeanItemContainer<>(
+                Vulnerability.class);
         AppSecService.getInstance().getVulnerabilities()
                 .forEach(container::addBean);
         grid.setContainerDataSource(container);
 
-        BeanItemContainer<DependencyDTO> depsCont = new BeanItemContainer<>(
-                DependencyDTO.class);
+        BeanItemContainer<Dependency> depsCont = new BeanItemContainer<>(
+                Dependency.class);
         getContainer().getItemIds().stream()
-                .map(VulnerabilityDTO::getDependency)
+                .map(Vulnerability::getDependency)
                 .collect(Collectors.toSet()).forEach(depsCont::addBean);
         dependency.setContainerDataSource(depsCont);
     }
@@ -185,13 +185,13 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
      * @param item
      *            filter
      */
-    public void filterOn(DependencyDTO item) {
+    public void filterOn(Dependency item) {
         clearFilters();
         dependency.setValue(item);
         applyFilters();
     }
 
-    private void showVulnerabilityDetails(VulnerabilityDTO vulnerabilityDTO) {
+    private void showVulnerabilityDetails(Vulnerability vulnerabilityDTO) {
         parent.showDetails(
                 new VulnerabilityDetailsView(vulnerabilityDTO, () -> {
                     parent.showMainContent();

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilityDetailsView.java
@@ -320,8 +320,8 @@ public class VulnerabilityDetailsView extends VerticalLayout {
         String id = vulnerabilityDTO.getIdentifier();
         AppSecData data = AppSecService.getInstance().getData();
 
-        AppSecData.VulnerabilityAssessment vulnerability = data.getVulnerabilities()
-                .get(id);
+        AppSecData.VulnerabilityAssessment vulnerability = data
+                .getVulnerabilities().get(id);
         if (vulnerability == null) {
             vulnerability = new AppSecData.VulnerabilityAssessment();
         }

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/ui/content/VulnerabilityDetailsView.java
@@ -22,10 +22,10 @@ import com.vaadin.appsec.backend.model.AppSecData;
 import com.vaadin.appsec.backend.model.analysis.AffectedVersion;
 import com.vaadin.appsec.backend.model.analysis.Assessment;
 import com.vaadin.appsec.backend.model.analysis.AssessmentStatus;
-import com.vaadin.appsec.backend.model.analysis.Vulnerability;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.analysis.VulnerabilityDetails;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 import com.vaadin.data.Property;
 import com.vaadin.shared.Version;
 import com.vaadin.shared.ui.MarginInfo;
@@ -54,14 +54,14 @@ public class VulnerabilityDetailsView extends VerticalLayout {
     private final DateFormat dateTimeFormatter = DateFormat.getDateTimeInstance(
             DateFormat.DEFAULT, DateFormat.DEFAULT,
             UI.getCurrent().getLocale());
-    private final VulnerabilityDTO vulnerabilityDTO;
+    private final Vulnerability vulnerabilityDTO;
     private final Runnable closeCallback;
     private Button saveButton;
     private ComboBox developerStatus;
     private TextArea developerAnalysis;
     private Label lastUpdated;
 
-    public VulnerabilityDetailsView(VulnerabilityDTO vulnerabilityDTO,
+    public VulnerabilityDetailsView(Vulnerability vulnerabilityDTO,
             Runnable closeCallback) {
         this.vulnerabilityDTO = vulnerabilityDTO;
         this.closeCallback = closeCallback;
@@ -264,10 +264,10 @@ public class VulnerabilityDetailsView extends VerticalLayout {
 
     private Optional<AffectedVersion> getAssessment() {
         String vulnerabilityId = vulnerabilityDTO.getIdentifier();
-        Vulnerability vulnerability = AppSecService.getInstance()
+        VulnerabilityDetails vulnerability = AppSecService.getInstance()
                 .getVulnerabilityAnalysis().getVulnerabilities()
                 .get(vulnerabilityId);
-        DependencyDTO dependency = vulnerabilityDTO.getDependency();
+        Dependency dependency = vulnerabilityDTO.getDependency();
         String groupAndName = dependency.toString();
         String version = dependency.getVersion();
         Assessment assessment = vulnerability.getAssessments()
@@ -320,10 +320,10 @@ public class VulnerabilityDetailsView extends VerticalLayout {
         String id = vulnerabilityDTO.getIdentifier();
         AppSecData data = AppSecService.getInstance().getData();
 
-        AppSecData.Vulnerability vulnerability = data.getVulnerabilities()
+        AppSecData.VulnerabilityAssessment vulnerability = data.getVulnerabilities()
                 .get(id);
         if (vulnerability == null) {
-            vulnerability = new AppSecData.Vulnerability();
+            vulnerability = new AppSecData.VulnerabilityAssessment();
         }
         vulnerability.setId(id);
         vulnerability.setStatus(

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/DependenciesTab.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/DependenciesTab.java
@@ -12,7 +12,7 @@ package com.vaadin.appsec.v8.ui.content;
 import java.util.stream.Collectors;
 
 import com.vaadin.appsec.backend.AppSecService;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.ui.ComboBox;
@@ -22,7 +22,7 @@ import com.vaadin.ui.Grid;
  * Dependencies tab content
  */
 public class DependenciesTab extends AbstractAppSecContent {
-    private Grid<DependencyDTO> grid;
+    private Grid<Dependency> grid;
     private ComboBox<String> group;
     private ComboBox<SeverityLevel> severity;
     private ComboBox<Integer> riskScore;
@@ -85,13 +85,13 @@ public class DependenciesTab extends AbstractAppSecContent {
         grid = new Grid<>();
         grid.setSelectionMode(Grid.SelectionMode.NONE);
         grid.setSizeFull();
-        grid.addColumn(DependencyDTO::getName).setCaption("Dependency");
-        grid.addColumn(DependencyDTO::getNumOfVulnerabilities)
+        grid.addColumn(Dependency::getName).setCaption("Dependency");
+        grid.addColumn(Dependency::getNumOfVulnerabilities)
                 .setCaption("# of vulnerabilities");
-        grid.addColumn(DependencyDTO::getGroup).setCaption("Dependency group");
-        grid.addColumn(DependencyDTO::getVersion).setCaption("Version");
-        grid.addColumn(DependencyDTO::getSeverityLevel).setCaption("Severity");
-        grid.addColumn(DependencyDTO::getRiskScore).setCaption("Risk score");
+        grid.addColumn(Dependency::getGroup).setCaption("Dependency group");
+        grid.addColumn(Dependency::getVersion).setCaption("Version");
+        grid.addColumn(Dependency::getSeverityLevel).setCaption("Severity");
+        grid.addColumn(Dependency::getRiskScore).setCaption("Risk score");
 
         getMainContent().addComponentsAndExpand(grid);
 
@@ -103,15 +103,15 @@ public class DependenciesTab extends AbstractAppSecContent {
     }
 
     @SuppressWarnings("unchecked")
-    private ListDataProvider<DependencyDTO> getListDataProvider() {
-        return (ListDataProvider<DependencyDTO>) grid.getDataProvider();
+    private ListDataProvider<Dependency> getListDataProvider() {
+        return (ListDataProvider<Dependency>) grid.getDataProvider();
     }
 
     @Override
     public void refresh() {
         grid.setItems(AppSecService.getInstance().getDependencies());
         group.setItems(getListDataProvider().getItems().stream()
-                .map(DependencyDTO::getGroup).collect(Collectors.toSet()));
+                .map(Dependency::getGroup).collect(Collectors.toSet()));
         applyFilters();
     }
 }

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/MainView.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/MainView.java
@@ -15,7 +15,7 @@ import java.util.Date;
 
 import com.vaadin.appsec.backend.AppSecService;
 import com.vaadin.appsec.backend.Registration;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.shared.communication.PushMode;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
@@ -103,7 +103,7 @@ public class MainView extends AbstractAppSecContent {
                 : formatter.format(Date.from(lastScan))));
     }
 
-    void showVulnerabilitiesTabFor(DependencyDTO item) {
+    void showVulnerabilitiesTabFor(Dependency item) {
         tabSheet.setSelectedTab(vulnerabilitiesTab);
         vulnerabilitiesTab.filterOn(item);
     }

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilitiesTab.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilitiesTab.java
@@ -14,9 +14,9 @@ import java.util.stream.Collectors;
 
 import com.vaadin.appsec.backend.AppSecService;
 import com.vaadin.appsec.backend.model.AppSecData;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 import com.vaadin.data.provider.ListDataProvider;
 import com.vaadin.ui.Alignment;
 import com.vaadin.ui.Button;
@@ -28,8 +28,8 @@ import com.vaadin.ui.Grid;
  */
 public class VulnerabilitiesTab extends AbstractAppSecContent {
     private AbstractAppSecContent parent;
-    private Grid<VulnerabilityDTO> grid;
-    private ComboBox<DependencyDTO> dependency;
+    private Grid<Vulnerability> grid;
+    private ComboBox<Dependency> dependency;
     private ComboBox<SeverityLevel> severity;
     private ComboBox<String> vaadinAnalysis;
     private ComboBox<AppSecData.VulnerabilityStatus> devAnalysis;
@@ -73,7 +73,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
 
     @Override
     protected void applyFilters() {
-        DependencyDTO dependencyFilter = dependency.getValue();
+        Dependency dependencyFilter = dependency.getValue();
         String vaadinAnalysisFilter = vaadinAnalysis.getValue();
         AppSecData.VulnerabilityStatus devAnalysisFilter = devAnalysis
                 .getValue();
@@ -105,16 +105,16 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
         grid.setSelectionMode(Grid.SelectionMode.SINGLE);
         grid.setSizeFull();
 
-        grid.addColumn(VulnerabilityDTO::getIdentifier)
+        grid.addColumn(Vulnerability::getIdentifier)
                 .setCaption("Vulnerability name or identifier");
-        grid.addColumn(VulnerabilityDTO::getDependency)
+        grid.addColumn(Vulnerability::getDependency)
                 .setCaption("Dependency");
-        grid.addColumn(VulnerabilityDTO::getSeverityLevel)
+        grid.addColumn(Vulnerability::getSeverityLevel)
                 .setCaption("Severity");
-        grid.addColumn(VulnerabilityDTO::getRiskScore).setCaption("Risk score");
-        grid.addColumn(VulnerabilityDTO::getVaadinAnalysis)
+        grid.addColumn(Vulnerability::getRiskScore).setCaption("Risk score");
+        grid.addColumn(Vulnerability::getVaadinAnalysis)
                 .setCaption("Vaadin analysis");
-        grid.addColumn(VulnerabilityDTO::getDeveloperStatus)
+        grid.addColumn(Vulnerability::getDeveloperStatus)
                 .setCaption("Developer analysis");
 
         getMainContent().addComponentsAndExpand(grid);
@@ -136,7 +136,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
                 .setEnabled(e.getFirstSelectedItem().isPresent()));
     }
 
-    private void showVulnerabilityDetails(VulnerabilityDTO vulnerabilityDTO) {
+    private void showVulnerabilityDetails(Vulnerability vulnerabilityDTO) {
         parent.showDetails(
                 new VulnerabilityDetailsView(vulnerabilityDTO, () -> {
                     parent.showMainContent();
@@ -145,17 +145,17 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
     }
 
     @SuppressWarnings("unchecked")
-    private ListDataProvider<VulnerabilityDTO> getListDataProvider() {
-        return (ListDataProvider<VulnerabilityDTO>) grid.getDataProvider();
+    private ListDataProvider<Vulnerability> getListDataProvider() {
+        return (ListDataProvider<Vulnerability>) grid.getDataProvider();
     }
 
     @Override
     public void refresh() {
-        Set<VulnerabilityDTO> selectedItems = grid.getSelectedItems();
+        Set<Vulnerability> selectedItems = grid.getSelectedItems();
         grid.deselectAll();
         grid.setItems(AppSecService.getInstance().getVulnerabilities());
         dependency.setItems(getListDataProvider().getItems().stream()
-                .map(VulnerabilityDTO::getDependency)
+                .map(Vulnerability::getDependency)
                 .collect(Collectors.toSet()));
         applyFilters();
         selectedItems.forEach(grid::select);
@@ -170,7 +170,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
      * @param item
      *            filter
      */
-    public void filterOn(DependencyDTO item) {
+    public void filterOn(Dependency item) {
         clearFilters();
         dependency.setValue(item);
         applyFilters();

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilitiesTab.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilitiesTab.java
@@ -107,10 +107,8 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
 
         grid.addColumn(Vulnerability::getIdentifier)
                 .setCaption("Vulnerability name or identifier");
-        grid.addColumn(Vulnerability::getDependency)
-                .setCaption("Dependency");
-        grid.addColumn(Vulnerability::getSeverityLevel)
-                .setCaption("Severity");
+        grid.addColumn(Vulnerability::getDependency).setCaption("Dependency");
+        grid.addColumn(Vulnerability::getSeverityLevel).setCaption("Severity");
         grid.addColumn(Vulnerability::getRiskScore).setCaption("Risk score");
         grid.addColumn(Vulnerability::getVaadinAnalysis)
                 .setCaption("Vaadin analysis");
@@ -155,8 +153,7 @@ public class VulnerabilitiesTab extends AbstractAppSecContent {
         grid.deselectAll();
         grid.setItems(AppSecService.getInstance().getVulnerabilities());
         dependency.setItems(getListDataProvider().getItems().stream()
-                .map(Vulnerability::getDependency)
-                .collect(Collectors.toSet()));
+                .map(Vulnerability::getDependency).collect(Collectors.toSet()));
         applyFilters();
         selectedItems.forEach(grid::select);
 

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
@@ -22,10 +22,10 @@ import com.vaadin.appsec.backend.model.AppSecData;
 import com.vaadin.appsec.backend.model.analysis.AffectedVersion;
 import com.vaadin.appsec.backend.model.analysis.Assessment;
 import com.vaadin.appsec.backend.model.analysis.AssessmentStatus;
-import com.vaadin.appsec.backend.model.analysis.Vulnerability;
-import com.vaadin.appsec.backend.model.dto.DependencyDTO;
+import com.vaadin.appsec.backend.model.analysis.VulnerabilityDetails;
+import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.SeverityLevel;
-import com.vaadin.appsec.backend.model.dto.VulnerabilityDTO;
+import com.vaadin.appsec.backend.model.dto.Vulnerability;
 import com.vaadin.data.HasValue;
 import com.vaadin.icons.VaadinIcons;
 import com.vaadin.shared.Version;
@@ -55,14 +55,14 @@ public class VulnerabilityDetailsView extends VerticalLayout {
     private final DateFormat dateTimeFormatter = DateFormat.getDateTimeInstance(
             DateFormat.DEFAULT, DateFormat.DEFAULT,
             UI.getCurrent().getLocale());
-    private final VulnerabilityDTO vulnerabilityDTO;
+    private final Vulnerability vulnerabilityDTO;
     private final Runnable closeCallback;
     private Button saveButton;
     private ComboBox<AppSecData.VulnerabilityStatus> developerStatus;
     private TextArea developerAnalysis;
     private Label lastUpdated;
 
-    public VulnerabilityDetailsView(VulnerabilityDTO vulnerabilityDTO,
+    public VulnerabilityDetailsView(Vulnerability vulnerabilityDTO,
             Runnable closeCallback) {
         this.vulnerabilityDTO = vulnerabilityDTO;
         this.closeCallback = closeCallback;
@@ -269,10 +269,10 @@ public class VulnerabilityDetailsView extends VerticalLayout {
 
     private Optional<AffectedVersion> getAssessment() {
         String vulnerabilityId = vulnerabilityDTO.getIdentifier();
-        Vulnerability vulnerability = AppSecService.getInstance()
+        VulnerabilityDetails vulnerability = AppSecService.getInstance()
                 .getVulnerabilityAnalysis().getVulnerabilities()
                 .get(vulnerabilityId);
-        DependencyDTO dependency = vulnerabilityDTO.getDependency();
+        Dependency dependency = vulnerabilityDTO.getDependency();
         String groupAndName = dependency.toString();
         String version = dependency.getVersion();
         Assessment assessment = vulnerability.getAssessments()
@@ -325,10 +325,10 @@ public class VulnerabilityDetailsView extends VerticalLayout {
         String id = vulnerabilityDTO.getIdentifier();
         AppSecData data = AppSecService.getInstance().getData();
 
-        AppSecData.Vulnerability vulnerability = data.getVulnerabilities()
+        AppSecData.VulnerabilityAssessment vulnerability = data.getVulnerabilities()
                 .get(id);
         if (vulnerability == null) {
-            vulnerability = new AppSecData.Vulnerability();
+            vulnerability = new AppSecData.VulnerabilityAssessment();
         }
         vulnerability.setId(id);
         vulnerability.setStatus(developerStatus.getValue());

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
@@ -325,8 +325,8 @@ public class VulnerabilityDetailsView extends VerticalLayout {
         String id = vulnerabilityDTO.getIdentifier();
         AppSecData data = AppSecService.getInstance().getData();
 
-        AppSecData.VulnerabilityAssessment vulnerability = data.getVulnerabilities()
-                .get(id);
+        AppSecData.VulnerabilityAssessment vulnerability = data
+                .getVulnerabilities().get(id);
         if (vulnerability == null) {
             vulnerability = new AppSecData.VulnerabilityAssessment();
         }


### PR DESCRIPTION
This applies some renaming to conform class names to common practices by removing the `*DTO` suffix.
