### PR TITLE
Remove fork mode when running the unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,9 +109,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
-                <configuration>
-                    <forkMode>always</forkMode>
-                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This PR removes the `forkMode` when running the unit tests (running each test in a separate jvm). It was added with this [commit](https://github.com/vaadin/appsec-kit/pull/40/commits/34e2ed549ae125eeb95a73f05c576a6e86707df7) and it was needed because of the previous solution in the `OpenSourceVulnerabilityClientTest`. This test uses a different solution now and it is not needed anymore.