### PR TITLE
Fix parent dependency handling when getting assessments

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -52,15 +52,22 @@ class AppSecDTOProvider {
     List<Dependency> getDependencies() {
         final List<OpenSourceVulnerability> vulnerabilities = vulnerabilityStore
                 .getVulnerabilities();
-        final List<org.cyclonedx.model.Dependency> dependencies = bomStore.getBom().getDependencies();
+        final List<org.cyclonedx.model.Dependency> dependencies = bomStore
+                .getBom().getDependencies();
 
         return bomStore.getBom().getComponents().stream().map(component -> {
-            Dependency dependency = new Dependency(component.getGroup(), component.getName(), component.getVersion());
-            Optional<org.cyclonedx.model.Dependency> bomDep = dependencies.stream()
-                    .filter(dep -> dep.getDependencies().stream().anyMatch(transDep -> transDep.getRef().equals(component.getBomRef())))
+            Dependency dependency = new Dependency(component.getGroup(),
+                    component.getName(), component.getVersion());
+            Optional<org.cyclonedx.model.Dependency> bomDep = dependencies
+                    .stream()
+                    .filter(dep -> dep.getDependencies().stream()
+                            .anyMatch(transDep -> transDep.getRef()
+                                    .equals(component.getBomRef())))
                     .findFirst();
-            bomDep.ifPresent(value -> dependency.setParentBomRef(value.getRef()));
-            updateVulnerabilityStatistics(dependency, vulnerabilities, getConcatDepName(component));
+            bomDep.ifPresent(
+                    value -> dependency.setParentBomRef(value.getRef()));
+            updateVulnerabilityStatistics(dependency, vulnerabilities,
+                    getConcatDepName(component));
             return dependency;
         }).collect(Collectors.toList());
     }

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
@@ -20,9 +20,8 @@ public class Dependency {
     private String group;
     private String name;
     private String version;
-
+    private String parentBomRef;
     private Integer numOfVulnerabilities;
-
     private SeverityLevel severityLevel;
     private Double riskScore;
 
@@ -100,21 +99,23 @@ public class Dependency {
         this.version = version;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        Dependency that = (Dependency) o;
-        return Objects.equals(group, that.group)
-                && Objects.equals(name, that.name)
-                && Objects.equals(version, that.version);
+    /**
+     * Gets parent dependency's BOM reference (purl).
+     *
+     * @return the parent dependency's BOM reference (purl)
+     */
+    public String getParentBomRef() {
+        return parentBomRef;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(group, name, version);
+    /**
+     * Sets parent dependency's BOM reference (purl).
+     *
+     * @param parentBomRef
+     *            the parent dependency's BOM reference (purl)
+     */
+    public void setParentBomRef(String parentBomRef) {
+        this.parentBomRef = parentBomRef;
     }
 
     /**
@@ -172,6 +173,23 @@ public class Dependency {
      */
     public void setRiskScore(Double riskScore) {
         this.riskScore = riskScore;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Dependency that = (Dependency) o;
+        return Objects.equals(group, that.group)
+                && Objects.equals(name, that.name)
+                && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(group, name, version);
     }
 
     @Override

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
@@ -135,9 +135,7 @@ public class VulnerabilityDetailsView extends VerticalLayout {
                 }).collect(Collectors.toList());
 
         left.addComponent(buildProperties());
-        if (vulnerabilityDTO.getDependency().getGroup().equals("com.vaadin")) {
-            left.addComponent(buildVaadinAnalysis());
-        }
+        left.addComponent(buildVaadinAnalysis());
         left.addComponents(vuDescTitle, vuDesc, refTitle);
         links.forEach(left::addComponent);
 
@@ -276,15 +274,29 @@ public class VulnerabilityDetailsView extends VerticalLayout {
             return Optional.empty();
         }
         Dependency dependency = vulnerabilityDTO.getDependency();
-        String groupAndName = dependency.toString();
-        String version = dependency.getVersion();
-        Assessment assessment = vulnerability.getAssessments()
-                .get(groupAndName);
+        String parentBomRef = dependency.getParentBomRef();
+        String groupAndName = bomRefToGroupAndName(parentBomRef);
+        Assessment assessment = vulnerability.getAssessments().get(groupAndName);
         if (assessment == null) {
             return Optional.empty();
         }
         return assessment.getAffectedVersions().values().stream()
-                .filter(v -> v.isInRange(version)).findFirst();
+                .filter(v -> v.isInRange(bomRefToVersion(parentBomRef))).findFirst();
+    }
+
+    private String bomRefToGroupAndName(String bomRef) {
+        // pkg:maven/com.vaadin/vaadin-server@8.13.0?type=jar
+        String[] bomRefParts = bomRef.split("/");
+        String[] depParts = bomRefParts[2].split("@");
+        return bomRefParts[1] + ":" + depParts[0];
+    }
+
+    private String bomRefToVersion(String bomRef) {
+        // pkg:maven/com.vaadin/vaadin-server@8.13.0?type=jar
+        String[] bomRefParts = bomRef.split("/");
+        String[] depParts = bomRefParts[2].split("@");
+        String[] verAndType = depParts[1].split("\\?");
+        return verAndType[0];
     }
 
     private Component buildProperties() {

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/ui/content/VulnerabilityDetailsView.java
@@ -276,12 +276,14 @@ public class VulnerabilityDetailsView extends VerticalLayout {
         Dependency dependency = vulnerabilityDTO.getDependency();
         String parentBomRef = dependency.getParentBomRef();
         String groupAndName = bomRefToGroupAndName(parentBomRef);
-        Assessment assessment = vulnerability.getAssessments().get(groupAndName);
+        Assessment assessment = vulnerability.getAssessments()
+                .get(groupAndName);
         if (assessment == null) {
             return Optional.empty();
         }
         return assessment.getAffectedVersions().values().stream()
-                .filter(v -> v.isInRange(bomRefToVersion(parentBomRef))).findFirst();
+                .filter(v -> v.isInRange(bomRefToVersion(parentBomRef)))
+                .findFirst();
     }
 
     private String bomRefToGroupAndName(String bomRef) {


### PR DESCRIPTION
This PR fixes parent dependency handling when getting assessments.

- Adds parent BOM reference to dependency DTO
- When getting the assessments for a vulnerability it checks if the affected dependency is a transitive dependency one of the dependencies in the assessments