### PR TITLE
Add license checker for V24 module

### DIFF
--- a/appsec-kit-demo-v24-spring/src/main/resources/META-INF/spring-devtools.properties
+++ b/appsec-kit-demo-v24-spring/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,3 @@
+# Exclude AppSec Kit classes to be loaded into the RestartClassLoader in development environment.
+# See more at https://docs.spring.io/spring-boot/docs/current/reference/html/using.html#using.devtools.restart.restart-vs-reload
+restart.exclude.appsec-kit=/appsec-kit-*

--- a/appsec-kit-v24/pom.xml
+++ b/appsec-kit-v24/pom.xml
@@ -117,4 +117,13 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
 </project>

--- a/appsec-kit-v24/pom.xml
+++ b/appsec-kit-v24/pom.xml
@@ -81,6 +81,28 @@
             <artifactId>vaadin-text-field-flow</artifactId>
             <version>${flow24.components.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/appsec-kit-v24/pom.xml
+++ b/appsec-kit-v24/pom.xml
@@ -86,20 +86,26 @@
             <artifactId>license-checker</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.5.0</version>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.5.0</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>

--- a/appsec-kit-v24/pom.xml
+++ b/appsec-kit-v24/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>license-checker</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.0</version>

--- a/appsec-kit-v24/src/main/java/com/vaadin/appsec/v24/service/LicenseCheckerServiceInitListener.java
+++ b/appsec-kit-v24/src/main/java/com/vaadin/appsec/v24/service/LicenseCheckerServiceInitListener.java
@@ -1,0 +1,56 @@
+/*-
+ * Copyright (C) 2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.appsec.v24.service;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+/**
+ * Service initialization listener to verify the license.
+ */
+public class LicenseCheckerServiceInitListener
+        implements VaadinServiceInitListener {
+
+    static final String PROPERTIES_RESOURCE = "appsec-kit.properties";
+
+    static final String VERSION_PROPERTY = "appsec-kit.version";
+
+    static final String PRODUCT_NAME = "vaadin-appsec-kit";
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        final VaadinService service = event.getSource();
+
+        try {
+            final Properties properties = new Properties();
+            properties.load(LicenseCheckerServiceInitListener.class
+                    .getClassLoader().getResourceAsStream(PROPERTIES_RESOURCE));
+            final String version = properties.getProperty(VERSION_PROPERTY);
+
+            UsageStatistics.markAsUsed(PRODUCT_NAME, version);
+
+            // Check the license at runtime if in development mode
+            if (!service.getDeploymentConfiguration().isProductionMode()) {
+                // Using a null BuildType to allow trial licensing builds
+                // The variable is defined to avoid method signature ambiguity
+                BuildType buildType = null;
+                LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
+            }
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/appsec-kit-v24/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/appsec-kit-v24/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,1 +1,2 @@
+com.vaadin.appsec.v24.service.LicenseCheckerServiceInitListener
 com.vaadin.appsec.v24.service.AppSecServiceInitListener

--- a/appsec-kit-v24/src/test/java/com/vaadin/appsec/v24/service/LicenseCheckerServiceInitListenerTest.java
+++ b/appsec-kit-v24/src/test/java/com/vaadin/appsec/v24/service/LicenseCheckerServiceInitListenerTest.java
@@ -1,0 +1,96 @@
+/*-
+ * Copyright (C) 2023 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.appsec.v24.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LicenseCheckerServiceInitListenerTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VaadinService service;
+
+    private MockedStatic<LicenseChecker> licenseChecker;
+
+    @BeforeEach
+    public void setup() {
+        licenseChecker = mockStatic(LicenseChecker.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        licenseChecker.close();
+    }
+
+    @Test
+    public void developmentMode_licenseIsCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(false);
+
+        final String version = getProperties().getProperty(
+                LicenseCheckerServiceInitListener.VERSION_PROPERTY);
+
+        // Assert version is in X.Y format
+        assertThat(version, matchesPattern("^\\d\\.\\d.*"));
+
+        final LicenseCheckerServiceInitListener listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        // Verify the license is checked
+        BuildType buildType = null;
+        licenseChecker.verify(() -> LicenseChecker.checkLicense(
+                LicenseCheckerServiceInitListener.PRODUCT_NAME, version,
+                buildType));
+    }
+
+    @Test
+    public void productionMode_licenseIsNotCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(true);
+
+        final LicenseCheckerServiceInitListener listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        licenseChecker.verifyNoInteractions();
+    }
+
+    private Properties getProperties() {
+        try {
+            InputStream resourceAsStream = LicenseCheckerServiceInitListener.class
+                    .getClassLoader().getResourceAsStream(
+                            LicenseCheckerServiceInitListener.PROPERTIES_RESOURCE);
+            final Properties properties = new Properties();
+            properties.load(resourceAsStream);
+            return properties;
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/LicenseCheckerWebListener.java
+++ b/appsec-kit-v7/src/main/java/com/vaadin/appsec/v7/service/LicenseCheckerWebListener.java
@@ -7,22 +7,26 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package com.vaadin.appsec.v8;
+package com.vaadin.appsec.v7.service;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
 
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
-import com.vaadin.server.ServiceInitEvent;
 import com.vaadin.server.VaadinService;
-import com.vaadin.server.VaadinServiceInitListener;
 
 /**
- * Service initialization listener to verify the license.
+ * Session listener to verify the license.
  */
-public class LicenseCheckerServiceInitListener
-        implements VaadinServiceInitListener {
+@WebListener
+public class LicenseCheckerWebListener implements HttpSessionListener {
 
     static final String PROPERTIES_RESOURCE = "appsec-kit.properties";
 
@@ -30,14 +34,30 @@ public class LicenseCheckerServiceInitListener
 
     static final String PRODUCT_NAME = "vaadin-appsec-kit";
 
-    @Override
-    public void serviceInit(ServiceInitEvent event) {
-        final VaadinService service = event.getSource();
+    private static final List<String> initializedVaadinServiceNames = new CopyOnWriteArrayList<>();
 
+    @Override
+    public synchronized void sessionCreated(HttpSessionEvent se) {
+        VaadinService vaadinService = VaadinService.getCurrent();
+        if (vaadinService != null) {
+            String serviceName = vaadinService.getServiceName();
+            if (!initializedVaadinServiceNames.contains(serviceName)) {
+                checkLicense(vaadinService);
+                initializedVaadinServiceNames.add(serviceName);
+            }
+        }
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        // NO-OP
+    }
+
+    private void checkLicense(VaadinService service) {
         try {
             final Properties properties = new Properties();
-            properties.load(LicenseCheckerServiceInitListener.class
-                    .getClassLoader().getResourceAsStream(PROPERTIES_RESOURCE));
+            properties.load(LicenseCheckerWebListener.class.getClassLoader()
+                    .getResourceAsStream(PROPERTIES_RESOURCE));
             final String version = properties.getProperty(VERSION_PROPERTY);
 
             // Check the license at runtime if in development mode

--- a/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/LicenseCheckerWebListenerTest.java
+++ b/appsec-kit-v7/src/test/java/com/vaadin/appsec/v7/service/LicenseCheckerWebListenerTest.java
@@ -7,7 +7,7 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package com.vaadin.appsec.v7;
+package com.vaadin.appsec.v7.service;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/LicenseCheckerServiceInitListener.java
+++ b/appsec-kit-v8/src/main/java/com/vaadin/appsec/v8/service/LicenseCheckerServiceInitListener.java
@@ -7,26 +7,22 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package com.vaadin.appsec.v7;
+package com.vaadin.appsec.v8.service;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.servlet.annotation.WebListener;
-import javax.servlet.http.HttpSessionEvent;
-import javax.servlet.http.HttpSessionListener;
 
 import com.vaadin.pro.licensechecker.BuildType;
 import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.server.ServiceInitEvent;
 import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinServiceInitListener;
 
 /**
- * Session listener to verify the license.
+ * Service initialization listener to verify the license.
  */
-@WebListener
-public class LicenseCheckerWebListener implements HttpSessionListener {
+public class LicenseCheckerServiceInitListener
+        implements VaadinServiceInitListener {
 
     static final String PROPERTIES_RESOURCE = "appsec-kit.properties";
 
@@ -34,30 +30,14 @@ public class LicenseCheckerWebListener implements HttpSessionListener {
 
     static final String PRODUCT_NAME = "vaadin-appsec-kit";
 
-    private static final List<String> initializedVaadinServiceNames = new CopyOnWriteArrayList<>();
-
     @Override
-    public synchronized void sessionCreated(HttpSessionEvent se) {
-        VaadinService vaadinService = VaadinService.getCurrent();
-        if (vaadinService != null) {
-            String serviceName = vaadinService.getServiceName();
-            if (!initializedVaadinServiceNames.contains(serviceName)) {
-                checkLicense(vaadinService);
-                initializedVaadinServiceNames.add(serviceName);
-            }
-        }
-    }
+    public void serviceInit(ServiceInitEvent event) {
+        final VaadinService service = event.getSource();
 
-    @Override
-    public void sessionDestroyed(HttpSessionEvent se) {
-        // NO-OP
-    }
-
-    private void checkLicense(VaadinService service) {
         try {
             final Properties properties = new Properties();
-            properties.load(LicenseCheckerWebListener.class.getClassLoader()
-                    .getResourceAsStream(PROPERTIES_RESOURCE));
+            properties.load(LicenseCheckerServiceInitListener.class
+                    .getClassLoader().getResourceAsStream(PROPERTIES_RESOURCE));
             final String version = properties.getProperty(VERSION_PROPERTY);
 
             // Check the license at runtime if in development mode

--- a/appsec-kit-v8/src/main/resources/META-INF/services/com.vaadin.server.VaadinServiceInitListener
+++ b/appsec-kit-v8/src/main/resources/META-INF/services/com.vaadin.server.VaadinServiceInitListener
@@ -1,3 +1,3 @@
-com.vaadin.appsec.v8.LicenseCheckerServiceInitListener
+com.vaadin.appsec.v8.service.LicenseCheckerServiceInitListener
 com.vaadin.appsec.v8.service.AppSecServiceInitListener
 com.vaadin.appsec.v8.service.NotificationInitListener

--- a/appsec-kit-v8/src/test/java/com/vaadin/appsec/v8/service/LicenseCheckerServiceInitListenerTest.java
+++ b/appsec-kit-v8/src/test/java/com/vaadin/appsec/v8/service/LicenseCheckerServiceInitListenerTest.java
@@ -7,7 +7,7 @@
  * See <https://vaadin.com/commercial-license-and-service-terms> for the full
  * license.
  */
-package com.vaadin.appsec.v8;
+package com.vaadin.appsec.v8.service;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
- Adds license checker for V24 module
- Moves license checkers to services in V7/V8 modules

Closes #95 