### PR TITLE
Fix dependency version check when assigning it to vulnerability

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.commonmark.node.Node;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
@@ -35,6 +36,7 @@ import com.vaadin.appsec.backend.model.dto.SeverityLevelComparator;
 import com.vaadin.appsec.backend.model.dto.Vulnerability;
 import com.vaadin.appsec.backend.model.osv.response.Affected;
 import com.vaadin.appsec.backend.model.osv.response.Ecosystem;
+import com.vaadin.appsec.backend.model.osv.response.Event;
 import com.vaadin.appsec.backend.model.osv.response.OpenSourceVulnerability;
 import com.vaadin.appsec.backend.model.osv.response.Range;
 import com.vaadin.appsec.backend.model.osv.response.Severity;
@@ -46,6 +48,11 @@ import static com.vaadin.appsec.backend.BillOfMaterialsStore.DEVELOPMENT_PROPERT
  * in the UI.
  */
 class AppSecDTOProvider {
+
+    private static final String INTRODUCED = "introduced";
+    private static final String FIXED = "fixed";
+    private static final String LAST_AFFECTED = "last_affected";
+    private static final String LIMIT = "limit";
 
     private final VulnerabilityStore vulnerabilityStore;
     private final BillOfMaterialsStore bomStore;
@@ -104,70 +111,184 @@ class AppSecDTOProvider {
         final List<Dependency> dependencies = getDependencies();
         final List<OpenSourceVulnerability> vulnerabilities = vulnerabilityStore
                 .getVulnerabilities();
-        final Map<String, AppSecData.VulnerabilityAssessment> devAnalysis = AppSecService
-                .getInstance().getData().getVulnerabilities();
-
-        Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
-
         List<Vulnerability> vulnerabilityDTOs = new ArrayList<>();
+
         for (OpenSourceVulnerability vuln : vulnerabilities) {
             for (Affected affected : vuln.getAffected()) {
                 String vulnDepGroup = AppSecUtils.getVulnDepGroup(affected);
                 String vulnDepName = AppSecUtils.getVulnDepName(affected);
+                List<String> versions = affected.getVersions();
+                List<Range> ranges = affected.getRanges();
 
-                Dependency depDTO = null;
                 for (Dependency dep : dependencies) {
-                    if (((dep.getGroup() == null && vulnDepGroup == null)
-                            || (dep.getGroup() != null
-                                    && dep.getGroup().equals(vulnDepGroup)))
-                            && dep.getName().equals(vulnDepName) && affected
-                                    .getVersions().contains(dep.getVersion())) {
-                        depDTO = dep;
+                    if (isVulnerable(dep, vulnDepGroup, vulnDepName, versions,
+                            ranges)) {
+                        Vulnerability vulnerabilityDTO = createVulnerabilityDTO(
+                                vuln, dep, affected);
+                        vulnerabilityDTOs.add(vulnerabilityDTO);
                     }
-                }
-
-                if (depDTO != null) {
-                    String id = getVulnerabilityId(vuln);
-                    Vulnerability vulnerabilityDTO = new Vulnerability(id);
-                    vulnerabilityDTO.setDependency(depDTO);
-                    vulnerabilityDTO.setDatePublished(vuln.getPublished());
-
-                    String patchedVersion = getPatchedVersion(affected)
-                            .orElse("---");
-                    vulnerabilityDTO.setPatchedVersion(patchedVersion);
-
-                    if (vuln.getDetails() != null) {
-                        Node document = parser.parse(vuln.getDetails());
-                        vulnerabilityDTO.setDetails(renderer.render(document));
-                    }
-
-                    Optional<AffectedVersion> vaadinAnalysis = getVaadinAnalysis(
-                            vulnerabilityDTO);
-                    vaadinAnalysis.ifPresent(affectedVersion -> vulnerabilityDTO
-                            .setVaadinAnalysis(affectedVersion.getStatus()));
-
-                    AppSecData.VulnerabilityAssessment vulnDevAnalysis = devAnalysis
-                            .get(id);
-                    if (vulnDevAnalysis != null) {
-                        vulnerabilityDTO.setDeveloperStatus(
-                                vulnDevAnalysis.getStatus());
-                        vulnerabilityDTO.setDeveloperAnalysis(
-                                vulnDevAnalysis.getDeveloperAnalysis());
-                        vulnerabilityDTO.setDeveloperUpdated(
-                                vulnDevAnalysis.getUpdated());
-                    }
-
-                    Set<String> urls = new HashSet<>();
-                    vuln.getReferences()
-                            .forEach(ref -> urls.add(ref.getUrl().toString()));
-                    vulnerabilityDTO.setReferenceUrls(urls);
-
-                    vulnerabilityDTOs.add(vulnerabilityDTO);
                 }
             }
         }
+
         return vulnerabilityDTOs;
+    }
+
+    // Pseudocode for evaluating if a given version is affected
+    // is available here https://ossf.github.io/osv-schema/#evaluation
+    private boolean isVulnerable(Dependency dep, String vulnDepGroup,
+            String vulnDepName, List<String> versions, List<Range> ranges) {
+        return isSameGroup(dep.getGroup(), vulnDepGroup)
+                && isSameName(dep.getName(), vulnDepName)
+                && isVersionAffected(dep.getVersion(), versions, ranges);
+    }
+
+    private boolean isSameGroup(String depGroup, String vulnDepGroup) {
+        return (depGroup == null && vulnDepGroup == null)
+                || (depGroup != null && depGroup.equals(vulnDepGroup));
+    }
+
+    private boolean isSameName(String depName, String vulnDepName) {
+        return depName.equals(vulnDepName);
+    }
+
+    private boolean isVersionAffected(String depVersion, List<String> versions,
+            List<Range> ranges) {
+        return includedInVersions(depVersion, versions)
+                || includedInRanges(depVersion, ranges);
+    }
+
+    private boolean includedInVersions(String depVersion,
+            List<String> versions) {
+        return versions != null && versions.contains(depVersion);
+    }
+
+    private boolean includedInRanges(String depVersion, List<Range> ranges) {
+        if (ranges != null) {
+            DefaultArtifactVersion depArtifactVersion = new DefaultArtifactVersion(
+                    depVersion);
+            for (Range range : ranges) {
+                if (beforeLimits(depArtifactVersion, range)) {
+                    boolean vulnerable = false;
+                    for (Event event : sortEvents(range.getEvents())) {
+                        Optional<DefaultArtifactVersion> introduced = getVersionFromEvent(
+                                event, INTRODUCED);
+                        Optional<DefaultArtifactVersion> fixed = getVersionFromEvent(
+                                event, FIXED);
+                        Optional<DefaultArtifactVersion> lastAffected = getVersionFromEvent(
+                                event, LAST_AFFECTED);
+
+                        if (introduced.isPresent() && depArtifactVersion
+                                .compareTo(introduced.get()) >= 0) {
+                            vulnerable = true;
+                        } else if (fixed.isPresent() && depArtifactVersion
+                                .compareTo(fixed.get()) >= 0) {
+                            vulnerable = false;
+                        } else if (lastAffected.isPresent()
+                                && depArtifactVersion
+                                        .compareTo(lastAffected.get()) > 0) {
+                            vulnerable = false;
+                        }
+                    }
+                    if (vulnerable) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private List<Event> sortEvents(List<Event> events) {
+        List<Event> sortedEvents = new ArrayList<>();
+        getEvent(events, INTRODUCED).ifPresent(sortedEvents::add);
+        getEvent(events, FIXED).ifPresent(sortedEvents::add);
+        getEvent(events, LAST_AFFECTED).ifPresent(sortedEvents::add);
+        getEvent(events, LIMIT).ifPresent(sortedEvents::add);
+        return sortedEvents;
+    }
+
+    private Optional<Event> getEvent(List<Event> events, String eventName) {
+        for (Event event : events) {
+            if (event.getAdditionalProperties().containsKey(eventName)) {
+                return Optional.of(event);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<DefaultArtifactVersion> getVersionFromEvent(Event event,
+            String eventName) {
+        if (event.getAdditionalProperties().containsKey(eventName)) {
+            String version = (String) event.getAdditionalProperties()
+                    .get(eventName);
+            return Optional.of(new DefaultArtifactVersion(version));
+        }
+        return Optional.empty();
+    }
+
+    private boolean beforeLimits(DefaultArtifactVersion version, Range range) {
+        boolean noLimitEvent = true;
+        for (Event event : range.getEvents()) {
+            if (event.getAdditionalProperties().containsKey(LIMIT)) {
+                noLimitEvent = false;
+                break;
+            }
+        }
+        if (noLimitEvent) {
+            return true;
+        }
+
+        for (Event event : range.getEvents()) {
+            String limit = (String) event.getAdditionalProperties().get(LIMIT);
+            DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(
+                    limit);
+            if (version.compareTo(artifactVersion) < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Vulnerability createVulnerabilityDTO(OpenSourceVulnerability vuln,
+            Dependency depDTO, Affected affected) {
+        String id = getVulnerabilityId(vuln);
+        Vulnerability vulnerabilityDTO = new Vulnerability(id);
+        vulnerabilityDTO.setDependency(depDTO);
+        vulnerabilityDTO.setDatePublished(vuln.getPublished());
+
+        String patchedVersion = getPatchedVersion(affected).orElse("---");
+        vulnerabilityDTO.setPatchedVersion(patchedVersion);
+
+        if (vuln.getDetails() != null) {
+            Node document = Parser.builder().build().parse(vuln.getDetails());
+            vulnerabilityDTO.setDetails(
+                    HtmlRenderer.builder().build().render(document));
+        }
+
+        Optional<AffectedVersion> vaadinAnalysis = getVaadinAnalysis(
+                vulnerabilityDTO);
+        vaadinAnalysis.ifPresent(affectedVersion -> vulnerabilityDTO
+                .setVaadinAnalysis(affectedVersion.getStatus()));
+
+        Map<String, AppSecData.VulnerabilityAssessment> vulnerabilityAssessments = AppSecService
+                .getInstance().getData().getVulnerabilities();
+        AppSecData.VulnerabilityAssessment vulnerabilityAssessment = vulnerabilityAssessments
+                .get(id);
+        if (vulnerabilityAssessment != null) {
+            vulnerabilityDTO
+                    .setDeveloperStatus(vulnerabilityAssessment.getStatus());
+            vulnerabilityDTO.setDeveloperAnalysis(
+                    vulnerabilityAssessment.getDeveloperAnalysis());
+            vulnerabilityDTO
+                    .setDeveloperUpdated(vulnerabilityAssessment.getUpdated());
+        }
+
+        Set<String> urls = new HashSet<>();
+        vuln.getReferences().forEach(ref -> urls.add(ref.getUrl().toString()));
+        vulnerabilityDTO.setReferenceUrls(urls);
+
+        return vulnerabilityDTO;
     }
 
     private boolean isDevDependency(Component component) {
@@ -282,7 +403,7 @@ class AppSecDTOProvider {
                 .filter(r -> r.getType().equals(rangeType)).findFirst();
         if (range.isPresent()) {
             Optional<Object> fixed = range.get().getEvents().stream()
-                    .map(event -> event.getAdditionalProperties().get("fixed"))
+                    .map(event -> event.getAdditionalProperties().get(FIXED))
                     .filter(Objects::nonNull).findFirst();
             if (fixed.isPresent()) {
                 return Optional.of((String) fixed.get());

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -111,7 +111,7 @@ class AppSecDTOProvider {
         final List<Dependency> dependencies = getDependencies();
         final List<OpenSourceVulnerability> vulnerabilities = vulnerabilityStore
                 .getVulnerabilities();
-        List<Vulnerability> vulnerabilityDTOs = new ArrayList<>();
+        Set<Vulnerability> vulnerabilityDTOs = new HashSet<>();
 
         for (OpenSourceVulnerability vuln : vulnerabilities) {
             for (Affected affected : vuln.getAffected()) {
@@ -131,7 +131,7 @@ class AppSecDTOProvider {
             }
         }
 
-        return vulnerabilityDTOs;
+        return new ArrayList<>(vulnerabilityDTOs);
     }
 
     // Pseudocode for evaluating if a given version is affected

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -170,7 +170,7 @@ class AppSecDTOProvider {
             for (Range range : ranges) {
                 if (beforeLimits(depArtifactVersion, range)) {
                     boolean vulnerable = false;
-                    for (Event event : sortEvents(range.getEvents())) {
+                    for (Event event : range.getEvents()) {
                         Optional<DefaultArtifactVersion> introduced = getVersionFromEvent(
                                 event, INTRODUCED);
                         Optional<DefaultArtifactVersion> fixed = getVersionFromEvent(
@@ -197,24 +197,6 @@ class AppSecDTOProvider {
             }
         }
         return false;
-    }
-
-    private List<Event> sortEvents(List<Event> events) {
-        List<Event> sortedEvents = new ArrayList<>();
-        getEvent(events, INTRODUCED).ifPresent(sortedEvents::add);
-        getEvent(events, FIXED).ifPresent(sortedEvents::add);
-        getEvent(events, LAST_AFFECTED).ifPresent(sortedEvents::add);
-        getEvent(events, LIMIT).ifPresent(sortedEvents::add);
-        return sortedEvents;
-    }
-
-    private Optional<Event> getEvent(List<Event> events, String eventName) {
-        for (Event event : events) {
-            if (event.getAdditionalProperties().containsKey(eventName)) {
-                return Optional.of(event);
-            }
-        }
-        return Optional.empty();
     }
 
     private Optional<DefaultArtifactVersion> getVersionFromEvent(Event event,

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/VulnerabilityStore.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/VulnerabilityStore.java
@@ -11,6 +11,7 @@ package com.vaadin.appsec.backend;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import org.cyclonedx.model.Component;
@@ -48,7 +49,7 @@ class VulnerabilityStore {
      */
     void init(List<OpenSourceVulnerability> vulnerabilities) {
         this.vulnerabilities.clear();
-        this.vulnerabilities.addAll(vulnerabilities);
+        this.vulnerabilities.addAll(new HashSet<>(vulnerabilities));
     }
 
     /**

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/dto/Dependency.java
@@ -259,6 +259,6 @@ public class Dependency {
 
     @Override
     public String toString() {
-        return group + ":" + name;
+        return (group != null ? group + ":" : "") + name;
     }
 }

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/OpenSourceVulnerability.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/OpenSourceVulnerability.java
@@ -11,6 +11,7 @@ package com.vaadin.appsec.backend.model.osv.response;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -382,6 +383,19 @@ public class OpenSourceVulnerability {
      */
     public void setDatabaseSpecific(DatabaseSpecific databaseSpecific) {
         this.databaseSpecific = databaseSpecific;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OpenSourceVulnerability that = (OpenSourceVulnerability) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     @Override

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/OpenSourceVulnerability.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/OpenSourceVulnerability.java
@@ -387,8 +387,12 @@ public class OpenSourceVulnerability {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         OpenSourceVulnerability that = (OpenSourceVulnerability) o;
         return Objects.equals(id, that.id);
     }

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
@@ -24,6 +24,7 @@ import com.vaadin.appsec.backend.model.osv.response.Ecosystem;
 public class AppSecDTOProviderTest {
 
     static final String TEST_RESOURCE_BOM_PATH = "../../../../bom.json";
+    static final String TEST_RESOURCE_BOM_NPM_PATH = "../../../../bom-npm.json";
 
     private BillOfMaterialsStore bomStore;
 
@@ -38,10 +39,15 @@ public class AppSecDTOProviderTest {
         vulnerabilityStore = new VulnerabilityStore(osvService, bomStore);
 
         // Init BOM Store
-        URL resource = AppSecDTOProviderTest.class
+        URL bomResource = AppSecDTOProviderTest.class
                 .getResource(TEST_RESOURCE_BOM_PATH);
+        URL bomNpmResource = AppSecDTOProviderTest.class
+                .getResource(TEST_RESOURCE_BOM_NPM_PATH);
         try {
-            bomStore.readBomFile(Paths.get(resource.toURI()), Ecosystem.MAVEN);
+            bomStore.readBomFile(Paths.get(bomResource.toURI()),
+                    Ecosystem.MAVEN);
+            bomStore.readBomFile(Paths.get(bomNpmResource.toURI()),
+                    Ecosystem.NPM);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -56,7 +62,7 @@ public class AppSecDTOProviderTest {
                 vulnerabilityStore, bomStore);
         List<Dependency> dependencies = dtoProvider.getDependencies();
 
-        Assert.assertEquals("Mismatch in expected dependency count.", 2,
+        Assert.assertEquals("Mismatch in expected dependency count.", 4,
                 dependencies.size());
     }
 
@@ -66,7 +72,7 @@ public class AppSecDTOProviderTest {
                 vulnerabilityStore, bomStore);
         List<Vulnerability> vulnerabilities = dtoProvider.getVulnerabilities();
 
-        Assert.assertEquals("Mismatch in expected vulnerability count.", 4,
+        Assert.assertEquals("Mismatch in expected vulnerability count.", 6,
                 vulnerabilities.size());
     }
 }

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
@@ -9,9 +9,15 @@
 
 package com.vaadin.appsec.backend;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,7 +25,17 @@ import org.junit.Test;
 
 import com.vaadin.appsec.backend.model.dto.Dependency;
 import com.vaadin.appsec.backend.model.dto.Vulnerability;
+import com.vaadin.appsec.backend.model.osv.response.Affected;
 import com.vaadin.appsec.backend.model.osv.response.Ecosystem;
+import com.vaadin.appsec.backend.model.osv.response.Event;
+import com.vaadin.appsec.backend.model.osv.response.OpenSourceVulnerability;
+import com.vaadin.appsec.backend.model.osv.response.Package;
+import com.vaadin.appsec.backend.model.osv.response.Range;
+import com.vaadin.appsec.backend.model.osv.response.Reference;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class AppSecDTOProviderTest {
 
@@ -27,15 +43,15 @@ public class AppSecDTOProviderTest {
     static final String TEST_RESOURCE_BOM_NPM_PATH = "../../../../bom-npm.json";
 
     private BillOfMaterialsStore bomStore;
-
     private VulnerabilityStore vulnerabilityStore;
 
-    private OpenSourceVulnerabilityService osvService;
-
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         bomStore = new BillOfMaterialsStore();
-        osvService = new OpenSourceVulnerabilityService(25);
+        OpenSourceVulnerabilityService osvService = mock(
+                OpenSourceVulnerabilityService.class);
+        when(osvService.getVulnerabilities(anyList()))
+                .thenReturn(createVulnerabilities());
         vulnerabilityStore = new VulnerabilityStore(osvService, bomStore);
 
         // Init BOM Store
@@ -44,8 +60,10 @@ public class AppSecDTOProviderTest {
         URL bomNpmResource = AppSecDTOProviderTest.class
                 .getResource(TEST_RESOURCE_BOM_NPM_PATH);
         try {
+            assert bomResource != null;
             bomStore.readBomFile(Paths.get(bomResource.toURI()),
                     Ecosystem.MAVEN);
+            assert bomNpmResource != null;
             bomStore.readBomFile(Paths.get(bomNpmResource.toURI()),
                     Ecosystem.NPM);
         } catch (Exception e) {
@@ -72,7 +90,87 @@ public class AppSecDTOProviderTest {
                 vulnerabilityStore, bomStore);
         List<Vulnerability> vulnerabilities = dtoProvider.getVulnerabilities();
 
-        Assert.assertEquals("Mismatch in expected vulnerability count.", 6,
+        Assert.assertEquals("Mismatch in expected vulnerability count.", 3,
                 vulnerabilities.size());
+    }
+
+    private List<OpenSourceVulnerability> createVulnerabilities()
+            throws Exception {
+        Reference reference = new Reference(Reference.Type.WEB,
+                new URI("https://wwww.reference.com"));
+
+        Affected affected1 = createAffected("Maven", "org.yaml:snakeyaml",
+                Arrays.asList("1.32", "1.33", "1.4"), Range.Type.ECOSYSTEM,
+                new HashMap<String, String>() {
+                    {
+                        put("introduced", "0");
+                        put("fixed", "2.0");
+                    }
+                });
+        Affected affected2 = createAffected("npm", "pac-resolver", null,
+                Range.Type.SEMVER, new HashMap<String, String>() {
+                    {
+                        put("introduced", "0");
+                        put("fixed", "5.0.0");
+                    }
+                });
+        Affected affected3 = createAffected("npm", "degenerator", null,
+                Range.Type.SEMVER, new HashMap<String, String>() {
+                    {
+                        put("introduced", "0");
+                        put("fixed", "3.0.1");
+                    }
+                });
+
+        OpenSourceVulnerability vulnerability1 = createVulnerability(
+                "GHSA-mjmj-j48q-9wg2", "CVE-2022-1471", reference,
+                Collections.singletonList(affected1));
+        OpenSourceVulnerability vulnerability2 = createVulnerability(
+                "GHSA-9j49-mfvp-vmhm", "CVE-2021-23406", reference,
+                Arrays.asList(affected2, affected3));
+        OpenSourceVulnerability vulnerability3 = createVulnerability(
+                "GHSA-9j49-mfvp-vmhm", "CVE-2021-23406", reference,
+                Arrays.asList(affected2, affected3));
+
+        return Arrays.asList(vulnerability1, vulnerability2, vulnerability3);
+    }
+
+    private OpenSourceVulnerability createVulnerability(String id, String alias,
+            Reference reference, List<Affected> affected) {
+        OpenSourceVulnerability vulnerability = new OpenSourceVulnerability();
+        vulnerability.setId(id);
+        vulnerability.setAliases(Collections.singletonList(alias));
+        vulnerability.setReferences(Collections.singletonList(reference));
+        vulnerability.setAffected(affected);
+        return vulnerability;
+    }
+
+    private Affected createAffected(String pkgEcosystem, String pkgName,
+            List<String> versions, Range.Type type,
+            Map<String, String> eventKeyValues) {
+        Affected affected = new Affected();
+        affected.setPackage(new Package(pkgEcosystem, pkgName));
+        affected.setVersions(versions);
+        affected.setRanges(
+                Collections.singletonList(createRange(type, eventKeyValues)));
+        return affected;
+    }
+
+    private Range createRange(Range.Type type,
+            Map<String, String> eventKeyValues) {
+        return new Range(type, null, createEvents(eventKeyValues), null);
+    }
+
+    private List<Event> createEvents(Map<String, String> eventKeyValues) {
+        List<Event> events = new ArrayList<>();
+        eventKeyValues
+                .forEach((key, value) -> events.add(createEvent(key, value)));
+        return events;
+    }
+
+    private Event createEvent(String eventKey, String eventValue) {
+        Event event = new Event();
+        event.setAdditionalProperty(eventKey, eventValue);
+        return event;
     }
 }

--- a/appsec-kit-backend/src/test/resources/bom-npm.json
+++ b/appsec-kit-backend/src/test/resources/bom-npm.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "serialNumber": "urn:uuid:522c97d5-7203-4a18-85b1-a89f344d8c31",
+  "metadata": {
+    "timestamp": "2023-10-11T11:38:43.358Z",
+    "tools": [
+      {
+        "name": "npm",
+        "version": "9.7.2"
+      },
+      {
+        "vendor": "@cyclonedx",
+        "name": "cyclonedx-npm",
+        "version": "1.14.1",
+        "externalReferences": [
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-node-npm.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \"repository.url\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-node-npm#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \"homepage\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-node-npm/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \"bugs.url\""
+          }
+        ]
+      },
+      {
+        "vendor": "@cyclonedx",
+        "name": "cyclonedx-library",
+        "version": "5.0.0",
+        "externalReferences": [
+          {
+            "url": "git+https://github.com/CycloneDX/cyclonedx-javascript-library.git",
+            "type": "vcs",
+            "comment": "as detected from PackageJson property \"repository.url\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library#readme",
+            "type": "website",
+            "comment": "as detected from PackageJson property \"homepage\""
+          },
+          {
+            "url": "https://github.com/CycloneDX/cyclonedx-javascript-library/issues",
+            "type": "issue-tracker",
+            "comment": "as detected from PackageJson property \"bugs.url\""
+          }
+        ]
+      }
+    ],
+    "component": {
+      "type": "application",
+      "name": "no-name",
+      "bom-ref": "-/no-name@-",
+      "licenses": [
+        {
+          "license": {
+            "name": "UNLICENSED"
+          }
+        }
+      ],
+      "purl": "pkg:npm/no-name",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": ""
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "pac-resolver",
+      "version": "4.0.0",
+      "bom-ref": "pac-resolver@4.0.0",
+      "author": "Nathan Rajlich",
+      "description": "Generates an asynchronous resolver function from a PAC file",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "f0b3d344531bb4c0233044ce77307f78febc97c683d22bf4853f01b92719ec51cb497de78cc53fe53755a8284bc8b89545f9ab10245605d040d8691d51b356ac"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/pac-resolver@4.0.0",
+      "externalReferences": [
+        {
+          "url": "git://github.com/TooTallNate/node-pac-resolver.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \"repository.url\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/node-pac-resolver#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \"homepage\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/node-pac-resolver/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \"bugs.url\""
+        },
+        {
+          "url": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-4.0.0.tgz",
+          "type": "distribution",
+          "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": "node_modules/pac-resolver"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "name": "degenerator",
+      "version": "2.2.0",
+      "bom-ref": "degenerator@2.2.0",
+      "author": "Nathan Rajlich",
+      "description": "Compiles sync functions into async generator functions",
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "6a241c428c05d35471148e192c5329cf2a2d6d0a2784da416a8e9d908f093e4e5afa19928d1e44ac7a76090c929907bca2cdd506a2c2221f3b9c3060657bec9a"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "purl": "pkg:npm/degenerator@2.2.0",
+      "externalReferences": [
+        {
+          "url": "git://github.com/TooTallNate/node-degenerator.git",
+          "type": "vcs",
+          "comment": "as detected from PackageJson property \"repository.url\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/node-degenerator#readme",
+          "type": "website",
+          "comment": "as detected from PackageJson property \"homepage\""
+        },
+        {
+          "url": "https://github.com/TooTallNate/node-degenerator/issues",
+          "type": "issue-tracker",
+          "comment": "as detected from PackageJson property \"bugs.url\""
+        },
+        {
+          "url": "https://registry.npmjs.org/degenerator/-/degenerator-2.2.0.tgz",
+          "type": "distribution",
+          "comment": "as detected from npm-ls property \"resolved\""
+        }
+      ],
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": "node_modules/degenerator"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "-/no-name@-",
+      "dependsOn": [
+        "pac-resolver@4.0.0"
+      ]
+    },
+    {
+      "ref": "pac-resolver@4.0.0",
+      "dependsOn": [
+        "degenerator@2.2.0",
+        "ip@1.1.8",
+        "netmask@1.0.6"
+      ]
+    },
+    {
+      "ref": "degenerator@2.2.0",
+      "dependsOn": [
+        "ast-types@0.13.4",
+        "escodegen@1.14.3",
+        "esprima@4.0.1"
+      ]
+    },
+    {
+      "ref": "netmask@1.0.6"
+    }
+  ]
+}

--- a/appsec-kit-backend/src/test/resources/bom.json
+++ b/appsec-kit-backend/src/test/resources/bom.json
@@ -1,10 +1,10 @@
 {
   "bomFormat" : "CycloneDX",
   "specVersion" : "1.4",
-  "serialNumber" : "urn:uuid:fcbf2e01-6661-44b6-b383-27b41feea161",
+  "serialNumber" : "urn:uuid:e22f4797-010a-4e95-8224-d0c945977b22",
   "version" : 1,
   "metadata" : {
-    "timestamp" : "2023-06-22T08:21:20Z",
+    "timestamp" : "2023-10-11T11:38:39Z",
     "tools" : [
       {
         "vendor" : "OWASP Foundation",
@@ -48,8 +48,8 @@
     ],
     "component" : {
       "group" : "com.vaadin",
-      "name" : "appsec-kit-demo-v8",
-      "version" : "1.0-SNAPSHOT",
+      "name" : "appsec-kit-demo-v24-spring",
+      "version" : "1.1-SNAPSHOT",
       "description" : "A parent POM for all artifacts by Vaadin Ltd.",
       "licenses" : [
         {
@@ -59,11 +59,11 @@
           }
         }
       ],
-      "purl" : "pkg:maven/com.vaadin/appsec-kit-demo-v8@1.0-SNAPSHOT?type=war",
+      "purl" : "pkg:maven/com.vaadin/appsec-kit-demo-v24-spring@1.1-SNAPSHOT?type=jar",
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "http://vaadin.com/appsec-kit/appsec-kit-demo-v8"
+          "url" : "http://vaadin.com/appsec-kit/appsec-kit-demo-v24-spring"
         },
         {
           "type" : "distribution",
@@ -71,16 +71,16 @@
         },
         {
           "type" : "vcs",
-          "url" : "https://github.com/vaadin/maven-integration/appsec-kit/appsec-kit-demo-v8"
+          "url" : "https://github.com/vaadin/maven-integration/appsec-kit/appsec-kit-demo-v24-spring"
         }
       ],
       "type" : "library",
-      "bom-ref" : "pkg:maven/com.vaadin/appsec-kit-demo-v8@1.0-SNAPSHOT?type=war"
+      "bom-ref" : "pkg:maven/com.vaadin/appsec-kit-demo-v24-spring@1.1-SNAPSHOT?type=jar"
     },
     "properties" : [
       {
         "name" : "maven.goal",
-        "value" : "makeBom"
+        "value" : "makeAggregateBom"
       },
       {
         "name" : "maven.scopes",
@@ -88,112 +88,45 @@
       }
     ]
   },
-  "components" : [
+  "components": [
     {
-      "group" : "com.vaadin",
-      "name" : "appsec-kit-v8",
-      "version" : "1.0-SNAPSHOT",
-      "description" : "A parent POM for all artifacts by Vaadin Ltd.",
-      "scope" : "optional",
+      "publisher" : "VMware, Inc.",
+      "group" : "org.springframework.boot",
+      "name" : "spring-boot-starter",
+      "version" : "3.1.4",
+      "description" : "Core starter, including auto-configuration support, logging and YAML",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "5a0f1c3e5a7a60dac232db36da040f00"
+          "content" : "5e34ae4dd67f995b245aabc1c5437f57"
         },
         {
           "alg" : "SHA-1",
-          "content" : "c7942a1491c1abaf5eb40da5825ef916a889205e"
+          "content" : "8a615e53a9f45eecc4821917b1423daa68afcf19"
         },
         {
           "alg" : "SHA-256",
-          "content" : "30ca874c079d06cea32152ddc71ba19912a08db887b19df58afc20fb04536a83"
+          "content" : "08266034df7c3ea63b961def06454571d4c3844ee22dab34ef5e292c9354f00d"
         },
         {
           "alg" : "SHA-512",
-          "content" : "4b1afd447e484b3049f8e06a1d8b45328b97233d7beef8f41e4ac67ac3594f67c3dfc39c123cb76cd50bc4d6a71b5780aa09bc0383ab70019cd3f254a6df7314"
+          "content" : "c92e3ae419908cca498c6b09139e5c0602d06ccb4018c276195d6135212214f4e17f02a007fb99ad682aacb94bdcd00b7d1dc0dbe19f73658ced4c81fc9973bf"
         },
         {
           "alg" : "SHA-384",
-          "content" : "61ad826dcf44bf24fff3654df8d8869d054707b771470dfb7ed050c6bcddc3cb4f6a19f32a336c948777f40eb0f5e0a6"
+          "content" : "97c414bdeb28ce5af9f3cf52b2dcac07d69cdba9169cd4a22fbdc73b55ab45cf029f6a701c91a2a0c4c4653fd4828969"
         },
         {
           "alg" : "SHA3-384",
-          "content" : "236b3e63f981697860f09a13a03c11d9f263540c4c1ab77faa588768a90b1518381537b948c48eedea3202f9caa5695c"
+          "content" : "138d9a134b6625c5ab5ceaae6ca75ecbe45bc949abef0dbccba94d498951a4f5a1d9c39cb9b57476994d9e34d6486044"
         },
         {
           "alg" : "SHA3-256",
-          "content" : "b2e4aa7e39b12922087c47454c170338e929ec9a58a70821bd136f9277b770af"
+          "content" : "479c1c9f07003503bbb51c0bdbe8bf840a8e257a8d1d4e02183de1f291e8e3ff"
         },
         {
           "alg" : "SHA3-512",
-          "content" : "8a06e9600f7f36608e9774a5861e83fe16729dec3553278e4bde104e84efec5113aaae6441c938e8579d4074edb4e70383414e76fbb00b8149f7766cb158fe71"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "name" : "Vaadin Commercial License and Service Terms",
-            "url" : "https://vaadin.com/commercial-license-and-service-terms"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/com.vaadin/appsec-kit-v8@1.0-SNAPSHOT?type=jar",
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://vaadin.com/appsec-kit/appsec-kit-v8"
-        },
-        {
-          "type" : "distribution",
-          "url" : "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2"
-        },
-        {
-          "type" : "vcs",
-          "url" : "https://github.com/vaadin/maven-integration/appsec-kit/appsec-kit-v8"
-        }
-      ],
-      "type" : "library",
-      "bom-ref" : "pkg:maven/com.vaadin/appsec-kit-v8@1.0-SNAPSHOT?type=jar"
-    },
-    {
-      "publisher" : "Vaadin Ltd",
-      "group" : "com.vaadin",
-      "name" : "vaadin-server",
-      "version" : "8.8.0",
-      "description" : "Vaadin server",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "5392f095044397e51dfea27f032e64e7"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "d18154c4f18b91adf665575d3754dd41d3a0773c"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "fda33acc45fca25ad9ce1d80ae11d7b20a15b3b7603d643ff1d90ea7590ecbee"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "5b76a643caba111cb5e08dcdfbbe2876fa60a3e595f129b27f9b2ec5833009de96af3e218c65d1170df757a2b76456da3ad5f12c42875b402e832b2ff30cb82a"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "932b9ba8983c1d5457eda71a6a5004e9351c8a7fa6abe33404e60a82a58d5420d880fd7e8d82d7210b39879df67ab3ed"
-        },
-        {
-          "alg" : "SHA3-384",
-          "content" : "7f38acab7d0515caa7dc196481aec4c72e47d03191684e9def70cd3114ac2fb9af8f2b0ad81cd953597e7d10d0934a90"
-        },
-        {
-          "alg" : "SHA3-256",
-          "content" : "515116480c15ff288207896f979fb35e35167349b6aa9ad153e206e259814ec3"
-        },
-        {
-          "alg" : "SHA3-512",
-          "content" : "b99643366bf78784971237cebb71c552b3495a8ee727eb9766f68f5ea10226aa2a3e3688cc50be076689ddf875a821769e9d6ee283321ce3c2ccf912a6e6ff41"
+          "content" : "82e5565c1781ee5a6fa39f138d8163b42c7650041b191b90279feed3257732e1ef015e00d4900ddb6ea759ce441c6d1b4dd87a67d7b855f00391dfbb91402d54"
         }
       ],
       "licenses" : [
@@ -203,32 +136,108 @@
           }
         }
       ],
-      "purl" : "pkg:maven/com.vaadin/vaadin-server@8.8.0?type=jar",
+      "purl" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.1.4?type=jar",
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://vaadin.com/"
+          "url" : "https://spring.io/projects/spring-boot"
+        },
+        {
+          "type" : "issue-tracker",
+          "url" : "https://github.com/spring-projects/spring-boot/issues"
+        },
+        {
+          "type" : "vcs",
+          "url" : "https://github.com/spring-projects/spring-boot"
+        }
+      ],
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.1.4?type=jar"
+    },
+    {
+      "group" : "org.yaml",
+      "name" : "snakeyaml",
+      "version" : "1.33",
+      "description" : "YAML 1.1 parser and emitter for Java",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "e0164a637c691c8cf01d29f90a709c02"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2cd0a87ff7df953f810c344bdf2fe3340b954c69"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "11ff459788f0a2d781f56a4a86d7e69202cebacd0273d5269c4ae9f02f3fd8f0"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "787b72aebb685689ab379ed8f238fc2f4175bb82d285909e39e7ff1ee1b9e64ad8878f4685dadde274f950b0dc77dca3082a52921c11094aa2a535672ae4f33c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "9f0a0a35df2b339830b9e78294634ea894e7096e01709c82d965e24a9fa9ac6ee15edbbbf23368dcd57741de5bf23086"
+        },
+        {
+          "alg" : "SHA3-384",
+          "content" : "91d8fd581d60be4090d3b522d8c119c12449cff2ce6c436d0e53977e1c9fea8686b2b360fb15f4c3507e4f243d7d6170"
+        },
+        {
+          "alg" : "SHA3-256",
+          "content" : "7dcf0429ecb923a66e00ec633bafeb297e3b90e1cc2be0f85443fd61367f355a"
+        },
+        {
+          "alg" : "SHA3-512",
+          "content" : "59b32910dddf63475893f7c830d58ca320cd6183704d80b8111cee7bb1674f97f5699c8ac52f905a5b9a20128b9e2b6a26a07490f217033c858d9c358bedcafc"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.yaml/snakeyaml@1.33?type=jar",
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml"
         },
         {
           "type" : "distribution",
           "url" : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
         },
         {
+          "type" : "issue-tracker",
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/issues"
+        },
+        {
           "type" : "vcs",
-          "url" : "https://github.com/vaadin/framework/vaadin-server"
+          "url" : "https://bitbucket.org/snakeyaml/snakeyaml/src"
         }
       ],
       "type" : "library",
-      "bom-ref" : "pkg:maven/com.vaadin/vaadin-server@8.8.0?type=jar"
+      "bom-ref" : "pkg:maven/org.yaml/snakeyaml@1.33?type=jar"
     }
   ],
-  "dependencies" : [
+  "dependencies": [
     {
-      "ref" : "pkg:maven/com.vaadin/appsec-kit-demo-v8@1.0-SNAPSHOT?type=war",
+      "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.1.4?type=jar",
       "dependsOn" : [
-        "pkg:maven/com.vaadin/appsec-kit-v8@1.0-SNAPSHOT?type=jar",
-        "pkg:maven/com.vaadin/vaadin-server@8.8.0?type=jar"
+        "pkg:maven/org.springframework.boot/spring-boot@3.1.4?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.1.4?type=jar",
+        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.1.4?type=jar",
+        "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
+        "pkg:maven/org.springframework/spring-core@6.0.12?type=jar",
+        "pkg:maven/org.yaml/snakeyaml@1.33?type=jar"
       ]
+    },
+    {
+      "ref" : "pkg:maven/org.yaml/snakeyaml@1.33?type=jar",
+      "dependsOn" : [ ]
     }
   ]
 }

--- a/appsec-kit-backend/src/test/resources/bom.json
+++ b/appsec-kit-backend/src/test/resources/bom.json
@@ -227,11 +227,6 @@
     {
       "ref" : "pkg:maven/org.springframework.boot/spring-boot-starter@3.1.4?type=jar",
       "dependsOn" : [
-        "pkg:maven/org.springframework.boot/spring-boot@3.1.4?type=jar",
-        "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@3.1.4?type=jar",
-        "pkg:maven/org.springframework.boot/spring-boot-starter-logging@3.1.4?type=jar",
-        "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1?type=jar",
-        "pkg:maven/org.springframework/spring-core@6.0.12?type=jar",
         "pkg:maven/org.yaml/snakeyaml@1.33?type=jar"
       ]
     },


### PR DESCRIPTION
Fixes dependency version check when assigning it to vulnerability by always checking the affected versions and affected ranges too (the related [OSV-schema description](https://ossf.github.io/osv-schema/#affected-fields)).

Closes #100
