### PR TITLE
Unsecure AppSec view using AnonymousAllowed annotation

### DIFF
--- a/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/AppSecView.java
+++ b/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/AppSecView.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.tabs.TabSheet;
 import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
 import com.vaadin.flow.shared.communication.PushMode;
 
 /**
@@ -40,6 +41,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 @Push
 @PageTitle("AppSec Kit")
 @CssImport("./appsec-kit.css")
+@AnonymousAllowed
 public class AppSecView extends AbstractAppSecView {
 
     private static final Logger LOGGER = LoggerFactory


### PR DESCRIPTION
Unsecures AppSec Kit's main view using `com.vaadin.flow.server.auth.AnonymousAllowed` annotation.

Closes #105 