### PR TITLE
fix: Read timeout

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/OpenSourceVulnerabilityClient.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/OpenSourceVulnerabilityClient.java
@@ -86,7 +86,7 @@ class OpenSourceVulnerabilityClient {
             String requestMethod) {
         HttpURLConnection connection;
         try {
-            URL url = new URL(urlStr);
+            URL url = URI.create(urlStr).toURL();
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod(requestMethod);
             connection.setRequestProperty("Content-Type", "application/json");

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/OpenSourceVulnerabilityClient.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/OpenSourceVulnerabilityClient.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
+import java.net.URI;
 import java.net.URL;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -92,7 +93,6 @@ class OpenSourceVulnerabilityClient {
             connection.setRequestProperty("Accept", "application/json");
             connection.setDoOutput(true);
             connection.setConnectTimeout(5000);
-            connection.setReadTimeout(5000);
         } catch (SocketTimeoutException e) {
             throw new AppSecException(
                     "Failed to connect or read from OSV API because of socket timeout",


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Remove read timeout from `HttpURLConnection` object so no more `SocketTimeoutException`s are thrown.

Fixes #122 

## Type of change

- [x] Bugfix
