### PR TITLE
Use data providers to set items for ComboBox and Grid

### DIFF
--- a/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/DependenciesView.java
+++ b/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/DependenciesView.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.appsec.views;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -98,12 +99,9 @@ public class DependenciesView extends AbstractAppSecView {
     public void refresh() {
         Set<Dependency> selectedItems = grid.getSelectedItems();
         grid.deselectAll();
-        grid.setItems(AppSecService.getInstance().getDependencies());
+        grid.setDataProvider(getDependencyDataProvider());
 
-        List<String> sortedGroups = getListDataProvider().getItems().stream()
-                .map(Dependency::getGroup).filter(Objects::nonNull).distinct()
-                .sorted().collect(Collectors.toList());
-        group.setItems(sortedGroups);
+        group.setDataProvider(getGroupDataProvider());
         applyFilters();
         selectedItems.forEach(grid::select);
     }
@@ -115,7 +113,7 @@ public class DependenciesView extends AbstractAppSecView {
 
     private void buildFilters() {
         ecosystem = new ComboBox<>("Ecosystem");
-        ecosystem.setItems(Ecosystem.MAVEN, Ecosystem.NPM);
+        ecosystem.setDataProvider(getEcosystemDataProvider());
         ecosystem.addValueChangeListener(event -> applyFilters());
 
         group = new ComboBox<>("Dependency group");
@@ -124,19 +122,16 @@ public class DependenciesView extends AbstractAppSecView {
 
         if (includeNpmDevDeps) {
             isDevelopment = new ComboBox<>("Is development?");
-            isDevelopment.setItems(Boolean.TRUE, Boolean.FALSE);
+            isDevelopment.setDataProvider(getIsDevelopmentDataProvider());
             isDevelopment.addValueChangeListener(event -> applyFilters());
         }
 
         severity = new ComboBox<>("Severity");
-        severity.setItems(SeverityLevel.NONE, SeverityLevel.LOW,
-                SeverityLevel.MEDIUM, SeverityLevel.HIGH,
-                SeverityLevel.CRITICAL);
+        severity.setDataProvider(getSeverityLevelDataProvider());
         severity.addValueChangeListener(event -> applyFilters());
 
         riskScore = new ComboBox<>("CVSS score");
-        riskScore.setItems(">=0", ">=1", ">=2", ">=3", ">=4", ">=5", ">=6",
-                ">=7", ">=8", ">=9", "=10");
+        riskScore.setDataProvider(getRiskScoreDataProvider());
         riskScore.addValueChangeListener(event -> applyFilters());
 
         List<Component> components = Stream
@@ -212,5 +207,34 @@ public class DependenciesView extends AbstractAppSecView {
     @SuppressWarnings("unchecked")
     private ListDataProvider<Dependency> getListDataProvider() {
         return (ListDataProvider<Dependency>) grid.getDataProvider();
+    }
+
+    private ListDataProvider<Dependency> getDependencyDataProvider() {
+        return new ListDataProvider<>(
+                AppSecService.getInstance().getDependencies());
+    }
+
+    private ListDataProvider<String> getGroupDataProvider() {
+        return new ListDataProvider<>(getDependencyDataProvider().getItems()
+                .stream().map(Dependency::getGroup).filter(Objects::nonNull)
+                .distinct().sorted().collect(Collectors.toList()));
+    }
+
+    private ListDataProvider<Ecosystem> getEcosystemDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(Ecosystem.values()));
+    }
+
+    private ListDataProvider<Boolean> getIsDevelopmentDataProvider() {
+        return new ListDataProvider<>(
+                Arrays.asList(Boolean.TRUE, Boolean.FALSE));
+    }
+
+    private ListDataProvider<SeverityLevel> getSeverityLevelDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(SeverityLevel.values()));
+    }
+
+    private ListDataProvider<String> getRiskScoreDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(">=0", ">=1", ">=2", ">=3",
+                ">=4", ">=5", ">=6", ">=7", ">=8", ">=9", "=10"));
     }
 }

--- a/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/VulnerabilitiesView.java
+++ b/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/VulnerabilitiesView.java
@@ -8,6 +8,7 @@
  */
 package com.vaadin.appsec.views;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -107,9 +108,8 @@ public class VulnerabilitiesView extends AbstractAppSecView {
     public void refresh() {
         Set<Vulnerability> selectedItems = grid.getSelectedItems();
         grid.deselectAll();
-        grid.setItems(AppSecService.getInstance().getVulnerabilities());
-        dependency.setItems(getListDataProvider().getItems().stream()
-                .map(Vulnerability::getDependency).collect(Collectors.toSet()));
+        grid.setDataProvider(getVulnerabilityDataProvider());
+        dependency.setDataProvider(getDependencyDataProvider());
         applyFilters();
         selectedItems.forEach(grid::select);
     }
@@ -121,7 +121,7 @@ public class VulnerabilitiesView extends AbstractAppSecView {
 
     private void buildFilters() {
         ecosystem = new ComboBox<>("Ecosystem");
-        ecosystem.setItems(Ecosystem.MAVEN, Ecosystem.NPM);
+        ecosystem.setDataProvider(getEcosystemDataProvider());
         ecosystem.addValueChangeListener(event -> applyFilters());
 
         dependency = new ComboBox<>("Dependency");
@@ -129,27 +129,19 @@ public class VulnerabilitiesView extends AbstractAppSecView {
         dependency.getStyle().set("--vaadin-combo-box-overlay-width", "350px");
 
         vaadinAnalysis = new ComboBox<>("Vaadin analysis");
-        vaadinAnalysis.setItems(AssessmentStatus.TRUE_POSITIVE,
-                AssessmentStatus.FALSE_POSITIVE, AssessmentStatus.UNDER_REVIEW);
+        vaadinAnalysis.setDataProvider(getAssessmentStatusDataProvider());
         vaadinAnalysis.addValueChangeListener(event -> applyFilters());
 
         developerAnalysis = new ComboBox<>("Developer analysis");
-        developerAnalysis.setItems(AppSecData.VulnerabilityStatus.NOT_SET,
-                AppSecData.VulnerabilityStatus.NOT_AFFECTED,
-                AppSecData.VulnerabilityStatus.FALSE_POSITIVE,
-                AppSecData.VulnerabilityStatus.IN_TRIAGE,
-                AppSecData.VulnerabilityStatus.EXPLOITABLE);
+        developerAnalysis.setDataProvider(getVulnerabilityStatusDataProvider());
         developerAnalysis.addValueChangeListener(event -> applyFilters());
 
         severity = new ComboBox<>("Severity");
-        severity.setItems(SeverityLevel.NONE, SeverityLevel.LOW,
-                SeverityLevel.MEDIUM, SeverityLevel.HIGH,
-                SeverityLevel.CRITICAL);
+        severity.setDataProvider(getSeverityLevelDataProvider());
         severity.addValueChangeListener(event -> applyFilters());
 
         riskScore = new ComboBox<>("CVSS score");
-        riskScore.setItems(">=0", ">=1", ">=2", ">=3", ">=4", ">=5", ">=6",
-                ">=7", ">=8", ">=9", "=10");
+        riskScore.setDataProvider(getRiskScoreDataProvider());
         riskScore.addValueChangeListener(event -> applyFilters());
 
         Component filterBar = buildFilterBar(ecosystem, dependency,
@@ -215,5 +207,38 @@ public class VulnerabilitiesView extends AbstractAppSecView {
     @SuppressWarnings("unchecked")
     private ListDataProvider<Vulnerability> getListDataProvider() {
         return (ListDataProvider<Vulnerability>) grid.getDataProvider();
+    }
+
+    private ListDataProvider<Vulnerability> getVulnerabilityDataProvider() {
+        return new ListDataProvider<>(
+                AppSecService.getInstance().getVulnerabilities());
+    }
+
+    private ListDataProvider<Dependency> getDependencyDataProvider() {
+        return new ListDataProvider<>(getVulnerabilityDataProvider().getItems()
+                .stream().map(Vulnerability::getDependency)
+                .collect(Collectors.toSet()));
+    }
+
+    private ListDataProvider<Ecosystem> getEcosystemDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(Ecosystem.values()));
+    }
+
+    private ListDataProvider<AssessmentStatus> getAssessmentStatusDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(AssessmentStatus.values()));
+    }
+
+    private ListDataProvider<AppSecData.VulnerabilityStatus> getVulnerabilityStatusDataProvider() {
+        return new ListDataProvider<>(
+                Arrays.asList(AppSecData.VulnerabilityStatus.values()));
+    }
+
+    private ListDataProvider<SeverityLevel> getSeverityLevelDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(SeverityLevel.values()));
+    }
+
+    private ListDataProvider<String> getRiskScoreDataProvider() {
+        return new ListDataProvider<>(Arrays.asList(">=0", ">=1", ">=2", ">=3",
+                ">=4", ">=5", ">=6", ">=7", ">=8", ">=9", "=10"));
     }
 }

--- a/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/VulnerabilityDetailsView.java
+++ b/appsec-kit-starter/src/main/java/com/vaadin/appsec/views/VulnerabilityDetailsView.java
@@ -10,6 +10,7 @@ package com.vaadin.appsec.views;
 
 import java.text.DateFormat;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -46,6 +47,7 @@ import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.server.Version;
 
 /**
@@ -328,17 +330,18 @@ public class VulnerabilityDetailsView extends VerticalLayout {
 
     private Component buildDeveloperStatus() {
         developerStatus = new ComboBox<>();
-        developerStatus.setItems(AppSecData.VulnerabilityStatus.NOT_SET,
-                AppSecData.VulnerabilityStatus.NOT_AFFECTED,
-                AppSecData.VulnerabilityStatus.FALSE_POSITIVE,
-                AppSecData.VulnerabilityStatus.IN_TRIAGE,
-                AppSecData.VulnerabilityStatus.EXPLOITABLE);
+        developerStatus.setDataProvider(getDeveloperStatusDataProvider());
         developerStatus.setPlaceholder("Select status");
         developerStatus.setWidth(100, Unit.PERCENTAGE);
         developerStatus.setLabel("Vulnerability status");
         developerStatus.setValue(vulnerabilityDTO.getDeveloperStatus());
         developerStatus.addValueChangeListener(this::developerAnalysisChanged);
         return developerStatus;
+    }
+
+    private ListDataProvider<AppSecData.VulnerabilityStatus> getDeveloperStatusDataProvider() {
+        return new ListDataProvider<>(
+                Arrays.asList(AppSecData.VulnerabilityStatus.values()));
     }
 
     private Component buildDeveloperAnalysis() {


### PR DESCRIPTION
## Description

Use `ComboBox::setDataProvider` and `Grid::setDataProvider` methods instead of the `setItems()` for setting items to have compatible solutions for both V14 and V23 versions.

Fixes #123 

## Type of change

- [x] Bugfix