### PR TITLE
chore: add Vaadin auto-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@
 **/bin
 *~
 
+# Vaadin auto-generated files
+appsec-kit-demo/frontend/generated
+appsec-kit-demo/frontend/index.html
+appsec-kit-demo/tsconfig.json
+appsec-kit-demo/types.d.ts
+appsec-kit-demo/vite.config.ts
+appsec-kit-demo/vite.generated.ts
+
 *pom.xml.versionsBackup
 
 **/target


### PR DESCRIPTION
## Description

I don't want to accidentally commit files that are auto-generated by Vaadin, so I added them to the `.gitignore` file.