### PR TITLE
Bump to 3.1-SNAPSHOT

### DIFF
--- a/appsec-kit-backend/pom.xml
+++ b/appsec-kit-backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>appsec-kit</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>appsec-kit-backend</artifactId>

--- a/appsec-kit-demo/pom.xml
+++ b/appsec-kit-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>appsec-kit</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>appsec-kit-demo</artifactId>

--- a/appsec-kit-starter/pom.xml
+++ b/appsec-kit-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>appsec-kit</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>appsec-kit-starter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <name>AppSec Kit</name>
 
     <artifactId>appsec-kit</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <licenses>
@@ -22,10 +22,10 @@
     </licenses>
 
     <properties>
-        <flow.version>24.2-SNAPSHOT</flow.version>
-        <flow.components.version>24.2-SNAPSHOT</flow.components.version>
+        <flow.version>24.3-SNAPSHOT</flow.version>
+        <flow.components.version>24.3-SNAPSHOT</flow.components.version>
 
-        <spring.boot.version>3.1.5</spring.boot.version>
+        <spring.boot.version>3.2.0</spring.boot.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
This bumps to 3.1 and updates Flow and Components and Spring versions to one used in V24.3