### PR TITLE
upgrade cyclonedx-core-java to 9.0.4

### DIFF
--- a/appsec-kit-backend/pom.xml
+++ b/appsec-kit-backend/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>us.springett</groupId>
             <artifactId>cvss-calculator</artifactId>
-            <version>1.4.1</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -50,6 +50,11 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>2.0.1.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.13</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -73,6 +78,12 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-junit-rule-no-dependencies</artifactId>
             <version>5.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/appsec-kit-backend/pom.xml
+++ b/appsec-kit-backend/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>8.0.3</version>
+            <version>9.0.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -352,6 +352,7 @@ class AppSecDTOProvider {
             OpenSourceVulnerability vulnerability) {
         return vulnerability.getSeverity().stream()
                 .map(severity -> Cvss.fromVector(severity.getScore()))
+                .filter(Objects::nonNull)
                 .map(cvss -> cvss.calculateScore().getBaseScore())
                 .max(Comparator.naturalOrder()).orElse(0.0);
     }
@@ -366,11 +367,13 @@ class AppSecDTOProvider {
         String cvssString = "";
         double tempBaseScore = 0.0;
         for (Severity severity : vulnerability.getSeverity()) {
-            double baseScore = Cvss.fromVector(severity.getScore())
-                    .calculateScore().getBaseScore();
-            if (baseScore > tempBaseScore) {
-                tempBaseScore = baseScore;
-                cvssString = severity.getScore();
+            Cvss cvss = Cvss.fromVector(severity.getScore());
+            if (cvss != null) {
+                double baseScore = cvss.calculateScore().getBaseScore();
+                if (baseScore > tempBaseScore) {
+                    tempBaseScore = baseScore;
+                    cvssString = severity.getScore();
+                }
             }
         }
 

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/Severity.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/Severity.java
@@ -86,9 +86,7 @@ public class Severity {
      * The severity type.
      */
     public enum Type {
-        CVSS_V2("CVSS_V2"),
-        CVSS_V3("CVSS_V3"),
-        CVSS_V4("CVSS_V4");
+        CVSS_V2("CVSS_V2"), CVSS_V3("CVSS_V3"), CVSS_V4("CVSS_V4");
 
         private final String value;
 

--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/Severity.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/model/osv/response/Severity.java
@@ -86,7 +86,9 @@ public class Severity {
      * The severity type.
      */
     public enum Type {
-        CVSS_V2("CVSS_V2"), CVSS_V3("CVSS_V3");
+        CVSS_V2("CVSS_V2"),
+        CVSS_V3("CVSS_V3"),
+        CVSS_V4("CVSS_V4");
 
         private final String value;
 

--- a/appsec-kit-demo/pom.xml
+++ b/appsec-kit-demo/pom.xml
@@ -112,7 +112,7 @@
                 </executions>
                 <configuration>
                     <projectType>library</projectType>
-                    <schemaVersion>1.5</schemaVersion>
+                    <schemaVersion>1.6</schemaVersion>
                     <includeBomSerialNumber>true</includeBomSerialNumber>
                     <includeCompileScope>true</includeCompileScope>
                     <includeProvidedScope>true</includeProvidedScope>
@@ -156,7 +156,7 @@
                                     <arguments>
                                         <argument>@cyclonedx/cyclonedx-npm</argument>
                                         <argument>--spec-version</argument>
-                                        <argument>1.5</argument>
+                                        <argument>1.6</argument>
                                         <argument>--output-file</argument>
                                         <argument>${project.build.outputDirectory}/resources/bom-npm.json</argument>
                                         <argument>--output-format</argument>

--- a/appsec-kit-demo/pom.xml
+++ b/appsec-kit-demo/pom.xml
@@ -112,7 +112,7 @@
                 </executions>
                 <configuration>
                     <projectType>library</projectType>
-                    <schemaVersion>1.6</schemaVersion>
+                    <schemaVersion>1.5</schemaVersion>
                     <includeBomSerialNumber>true</includeBomSerialNumber>
                     <includeCompileScope>true</includeCompileScope>
                     <includeProvidedScope>true</includeProvidedScope>
@@ -156,7 +156,7 @@
                                     <arguments>
                                         <argument>@cyclonedx/cyclonedx-npm</argument>
                                         <argument>--spec-version</argument>
-                                        <argument>1.6</argument>
+                                        <argument>1.5</argument>
                                         <argument>--output-file</argument>
                                         <argument>${project.build.outputDirectory}/resources/bom-npm.json</argument>
                                         <argument>--output-format</argument>


### PR DESCRIPTION
- Resolves [CVE-2024-38374](https://secalerts.co/vulnerability/CVE-2024-38374) vulnerability.
- Makes `appsec-kit` compatible with `cyclonedx-core-java:9.0.4`


Closes #180 