### PR TITLE
Add check for supported CVSS versions

### DIFF
--- a/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
+++ b/appsec-kit-backend/src/main/java/com/vaadin/appsec/backend/AppSecDTOProvider.java
@@ -351,6 +351,7 @@ class AppSecDTOProvider {
     private Double getHighestCvssScoreNumber(
             OpenSourceVulnerability vulnerability) {
         return vulnerability.getSeverity().stream()
+                .filter(severity -> isSupportedCvssType(severity.getType()))
                 .map(severity -> Cvss.fromVector(severity.getScore()))
                 .filter(Objects::nonNull)
                 .map(cvss -> cvss.calculateScore().getBaseScore())
@@ -367,18 +368,24 @@ class AppSecDTOProvider {
         String cvssString = "";
         double tempBaseScore = 0.0;
         for (Severity severity : vulnerability.getSeverity()) {
-            Cvss cvss = Cvss.fromVector(severity.getScore());
-            if (cvss != null) {
-                double baseScore = cvss.calculateScore().getBaseScore();
-                if (baseScore > tempBaseScore) {
-                    tempBaseScore = baseScore;
-                    cvssString = severity.getScore();
+            if (isSupportedCvssType(severity.getType())) {
+                Cvss cvss = Cvss.fromVector(severity.getScore());
+                if (cvss != null) {
+                    double baseScore = cvss.calculateScore().getBaseScore();
+                    if (baseScore > tempBaseScore) {
+                        tempBaseScore = baseScore;
+                        cvssString = severity.getScore();
+                    }
                 }
             }
         }
 
         return tempBaseScore >= highestScoreNumber ? cvssString
                 : highestScoreString;
+    }
+
+    private boolean isSupportedCvssType(Severity.Type type) {
+        return type == Severity.Type.CVSS_V2 || type == Severity.Type.CVSS_V3;
     }
 
     private Optional<String> getPatchedVersion(Affected affected) {

--- a/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
+++ b/appsec-kit-backend/src/test/java/com/vaadin/appsec/backend/AppSecDTOProviderTest.java
@@ -30,6 +30,7 @@ import com.vaadin.appsec.backend.model.osv.response.OpenSourceVulnerability;
 import com.vaadin.appsec.backend.model.osv.response.Package;
 import com.vaadin.appsec.backend.model.osv.response.Range;
 import com.vaadin.appsec.backend.model.osv.response.Reference;
+import com.vaadin.appsec.backend.model.osv.response.Severity;
 
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -158,15 +159,20 @@ public class AppSecDTOProviderTest {
                     }
                 });
 
+        Severity severity1 = new Severity(Severity.Type.CVSS_V3,
+                "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N");
+        Severity severity2 = new Severity(Severity.Type.CVSS_V4,
+                "CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N");
+
         OpenSourceVulnerability vulnerability1 = createVulnerability(
                 "GHSA-mjmj-j48q-9wg2", "CVE-2022-1471", reference,
-                List.of(affected1));
+                List.of(affected1), List.of(severity1, severity2));
         OpenSourceVulnerability vulnerability2 = createVulnerability(
                 "GHSA-9j49-mfvp-vmhm", "CVE-2021-23406", reference,
-                List.of(affected2, affected3));
+                List.of(affected2, affected3), List.of());
         OpenSourceVulnerability vulnerability3 = createVulnerability(
                 "GHSA-9j49-mfvp-vmhm", "CVE-2021-23406", reference,
-                List.of(affected2, affected3));
+                List.of(affected2, affected3), List.of());
 
         return Arrays.asList(vulnerability1, vulnerability2, vulnerability3);
     }
@@ -194,21 +200,23 @@ public class AppSecDTOProviderTest {
 
         OpenSourceVulnerability vulnerability1 = createVulnerability(
                 "GHSA-mjmj-j48q-9wg2", "CVE-2022-1471", reference,
-                List.of(affected1));
+                List.of(affected1), List.of());
         OpenSourceVulnerability vulnerability2 = createVulnerability(
                 "GHSA-9j49-mfvp-vmhm", "CVE-2021-23406", reference,
-                List.of(affected2));
+                List.of(affected2), List.of());
 
         return Arrays.asList(vulnerability1, vulnerability2);
     }
 
     private OpenSourceVulnerability createVulnerability(String id, String alias,
-            Reference reference, List<Affected> affected) {
+            Reference reference, List<Affected> affected,
+            List<Severity> severity) {
         OpenSourceVulnerability vulnerability = new OpenSourceVulnerability();
         vulnerability.setId(id);
         vulnerability.setAliases(Collections.singletonList(alias));
         vulnerability.setReferences(Collections.singletonList(reference));
         vulnerability.setAffected(affected);
+        vulnerability.setSeverity(severity);
         return vulnerability;
     }
 


### PR DESCRIPTION
CVSS v4.0 has been [introduced](https://www.first.org/newsroom/releases/20231101) last year.
OSV can already [return](https://github.com/google/osv.dev/issues/2335) CVSS v4.0 score vectors in the response.
However, the CVSS v4.0 is [not supported](https://github.com/stevespringett/cvss-calculator/issues/78) yet by the `cvss-calculator` used in the AppSec Kit to calculate the score from the vector string.

This PR adds a check for the supported CVSS versions to avoid errors when a CVSS v4.0 score is present in the response.

Closes #181 