### PR TITLE
fix: make LicenseCheckerServiceInitListener no-args constructor public

### DIFF
--- a/appsec-kit-starter/src/main/java/com/vaadin/appsec/service/LicenseCheckerServiceInitListener.java
+++ b/appsec-kit-starter/src/main/java/com/vaadin/appsec/service/LicenseCheckerServiceInitListener.java
@@ -38,7 +38,11 @@ public class LicenseCheckerServiceInitListener
         }
     }
 
-    protected LicenseCheckerServiceInitListener() {
+    /**
+     * Initializes a license checking mechanism for Appsec Kit using its product
+     * name and current version.
+     */
+    public LicenseCheckerServiceInitListener() {
         super(PRODUCT_NAME, PRODUCT_VERSION);
     }
 }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Prevents Spring DI errors like

```
java.util.ServiceConfigurationError: com.vaadin.flow.server.VaadinServiceInitListener: com.vaadin.appsec.service.LicenseCheckerServiceInitListener Unable to get public no-arg constructor
Caused by: java.lang.NoSuchMethodException: com.vaadin.appsec.service.LicenseCheckerServiceInitListener.<init>()
        at java.base/java.lang.Class.getConstructor0(Class.java:3761) ~[na:na]
```

because no public no-args constructor found.
