### PR TITLE
chore: upgrade jackson.version to 2.21.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.surefire.version>3.5.4</maven.surefire.version>
         <maven.formatter.version>2.16.0</maven.formatter.version>
-        <jackson.version>2.21.5</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
         <maven.surefire.version>3.5.4</maven.surefire.version>
         <maven.formatter.version>2.16.0</maven.formatter.version>
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.version>2.21.5</jackson.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
https://github.com/advisories/GHSA-5hh8-q8hv-fr38
https://github.com/advisories/GHSA-hgj6-7826-r7m5
https://github.com/advisories/GHSA-j3rv-43j4-c7qm
https://github.com/advisories/GHSA-rcqc-6cw3-h962
https://github.com/advisories/GHSA-rmj7-2vxq-3g9f
https://github.com/advisories/GHSA-9fxm-vc8v-hj55

seems there are one CVE asking for 2.21.5, but that version is not yet ready.
https://github.com/advisories/GHSA-5jmj-h7xm-6q6v
